### PR TITLE
fix(reporting): avoid errors when using $ in queries for json_extract

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
@@ -228,6 +228,11 @@ class DefaultReportCalculationUseCase(
         val queryArgs = mutableListOf<String>()
 
         for (placeholder in placeholders) {
+            if (!args.containsKey(placeholder)) {
+                // skip potential placeholders that are not in args, these may be sqlite-related tokens (e.g. for json_extract)
+                continue
+            }
+
             val placeholderValue = args.getValue(placeholder)
             queryArgs.add(placeholderValue)
             sqlQuery = sqlQuery.replace("$$placeholder", "?")

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
@@ -215,7 +215,7 @@ class DefaultReportCalculationUseCaseTest {
             version = 1,
             items = listOf(
                 ReportItem.ReportQuery(
-                    sql = "SELECT * FROM foo WHERE time BETWEEN \$from and \$to",
+                    sql = "SELECT *, json_extract(foo.children, '$[0]') FROM foo WHERE time BETWEEN \$from and \$to",
                 )
             ),
             transformations = mapOf(
@@ -269,7 +269,7 @@ class DefaultReportCalculationUseCaseTest {
         verify(queryStorage).executeQuery(
             eq(
                 QueryRequest(
-                    query = "SELECT * FROM foo WHERE time BETWEEN ? and ?",
+                    query = "SELECT *, json_extract(foo.children, '\$[0]') FROM foo WHERE time BETWEEN ? and ?",
                     args = listOf(
                         "2010-01-15", "2010-01-16T23:59:59.999Z"
                     )


### PR DESCRIPTION
by keeping $placeholders that don't match an arg unchanged