### PR TITLE
fix(queue): surface wrapped listener errors cleanly and throttle redeclare noise

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/domain/DomainUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/domain/DomainUseCase.kt
@@ -64,7 +64,7 @@ abstract class DomainUseCase<R : UseCaseRequest, D : UseCaseData> {
                 }
             }
 
-        logger.debug("[{}] {}", errorCode, it.localizedMessage, it.cause)
+        logger.warn("[{}] {}", errorCode, it.localizedMessage, it)
 
         return UseCaseOutcome.Failure(
             errorMessage = it.localizedMessage,

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueConfiguration.kt
@@ -4,6 +4,7 @@ import com.aamdigital.aambackendservice.common.queue.core.DefaultQueueMessagePar
 import com.aamdigital.aambackendservice.common.queue.core.QueueMessageParser
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.amqp.AmqpRejectAndDontRequeueException
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
@@ -13,10 +14,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.amqp.RabbitRetryTemplateCustomizer
 import org.springframework.boot.autoconfigure.amqp.RabbitTemplateConfigurer
 import org.springframework.boot.autoconfigure.amqp.RabbitTemplateCustomizer
+import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.retry.policy.SimpleRetryPolicy
+import org.springframework.util.ErrorHandler
 
 @Configuration
 class QueueConfiguration {
@@ -72,4 +75,30 @@ class QueueConfiguration {
 
     @Bean
     fun defaultMessageConverter(): MessageConverter = Jackson2JsonMessageConverter()
+
+    /**
+     * Central [ErrorHandler] for all listener containers. See [QueueErrorHandler] - it logs the unwrapped root
+     * cause of every permanent listener failure at ERROR so it is reported once to Sentry, grouped by its real
+     * cause, instead of each consumer reporting (or silently dropping) errors on its own.
+     */
+    @Bean
+    fun queueErrorHandler(): ErrorHandler = QueueErrorHandler()
+
+    /**
+     * Override Boot's auto-configured listener container factory (same name, so Boot backs off) purely to
+     * attach [queueErrorHandler]. The [SimpleRabbitListenerContainerFactoryConfigurer] applies all the usual
+     * `spring.rabbitmq.listener.simple.*` settings, the retry advice (incl. [nonRetryablePermanentFailures])
+     * and the message converter, so nothing else changes.
+     */
+    @Bean
+    fun rabbitListenerContainerFactory(
+        configurer: SimpleRabbitListenerContainerFactoryConfigurer,
+        connectionFactory: ConnectionFactory,
+        queueErrorHandler: ErrorHandler,
+    ): SimpleRabbitListenerContainerFactory {
+        val factory = SimpleRabbitListenerContainerFactory()
+        configurer.configure(factory, connectionFactory)
+        factory.setErrorHandler(queueErrorHandler)
+        return factory
+    }
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueErrorHandler.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueErrorHandler.kt
@@ -1,0 +1,27 @@
+package com.aamdigital.aambackendservice.common.queue.di
+
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler
+import org.springframework.core.NestedExceptionUtils
+
+/**
+ * Central error handler for every `@RabbitListener` container.
+ *
+ * Spring's default [ConditionalRejectingErrorHandler] logs only the wrapping `ListenerExecutionFailedException`
+ * at WARN, which (a) sits below the Sentry minimum event level, so permanent failures never become Sentry
+ * events, and (b) buries the real cause under AMQP framework frames. Today the only consumer whose failures
+ * reach Sentry is the one that calls `Sentry.captureException` by hand.
+ *
+ * This handler additionally logs the unwrapped *root cause* at ERROR, so every permanent listener failure is
+ * reported once, grouped by its actual cause - while delegating the reject/requeue decision to the default
+ * strategy, leaving message disposition unchanged.
+ */
+class QueueErrorHandler : ConditionalRejectingErrorHandler() {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun handleError(t: Throwable) {
+        val rootCause = NestedExceptionUtils.getMostSpecificCause(t)
+        logger.error("RabbitMQ listener failed: {}", rootCause.message, rootCause)
+        super.handleError(t)
+    }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessor.kt
@@ -2,36 +2,62 @@ package com.aamdigital.aambackendservice.common.queue.di
 
 import io.sentry.EventProcessor
 import io.sentry.Hint
-import io.sentry.Sentry
 import io.sentry.SentryEvent
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.util.*
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
 
+/**
+ * Throttles the noisy, low-value RabbitMQ "Failed to check/redeclare auto-delete queue(s)." error that
+ * Spring AMQP logs whenever a listener container races broker readiness on (re)connect. Without throttling a
+ * single crash-looping instance can emit tens of thousands of identical events (see Sentry
+ * AAM-BACKEND-SERVICE-22, which reached ~47k events from one deployment).
+ *
+ * At most one such event is forwarded to Sentry per [throttleWindow]; the rest are dropped. Keeping a periodic
+ * sample means the condition stays visible if it ever recurs after the deployment-level fix, without flooding
+ * the quota.
+ */
 @Component
-class QueueSentryEventProcessor : EventProcessor {
+class QueueSentryEventProcessor(
+    @Value("\${aam.sentry.redeclare-queue-error.throttle-window:PT5M}")
+    private val throttleWindow: Duration = Duration.ofMinutes(5),
+) : EventProcessor {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    init {
-        logger.info("SENTRY: QueueSentryEventProcessor initialized " + Sentry.isEnabled())
-    }
-
-    private var lastFailedCheckQueuesError: Date? = null
+    // shared across consumer threads, so guard the "last forwarded" marker atomically
+    private val lastForwarded = AtomicReference(Instant.MIN)
 
     override fun process(
         event: SentryEvent,
-        hint: Hint
+        hint: Hint,
     ): SentryEvent? {
-        logger.trace("SENTRY EVENT: ${event.throwable?.javaClass?.toString()} ${event.message?.toString()}")
-
-        if (event.message?.toString() == "Failed to check/redeclare auto-delete queue(s).") {
-            if (lastFailedCheckQueuesError == null) {
-                lastFailedCheckQueuesError = event.timestamp
-                logger.info("SENTRY: QueueSentryEventProcessor: ignoring first Queue error")
-                return null
-            }
+        // Match the Sentry message model's actual fields. `Message.toString()` is NOT overridden, so the
+        // previous `event.message?.toString()` check never matched and this processor was a silent no-op -
+        // which is why all ~47k events reached Sentry. The logback integration always sets `formatted`.
+        val message = event.message?.formatted ?: event.message?.message ?: event.throwable?.message
+        if (message != THROTTLED_MESSAGE) {
+            return event
         }
 
-        return event
+        val now = event.timestamp?.toInstant() ?: Instant.now()
+
+        while (true) {
+            val last = lastForwarded.get()
+            if (Duration.between(last, now) < throttleWindow) {
+                logger.debug("Throttling repeated '{}' event", THROTTLED_MESSAGE)
+                return null
+            }
+            if (lastForwarded.compareAndSet(last, now)) {
+                return event
+            }
+            // lost the race to another thread; retry with the updated marker
+        }
+    }
+
+    companion object {
+        private const val THROTTLED_MESSAGE = "Failed to check/redeclare auto-delete queue(s)."
     }
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessor.kt
@@ -13,8 +13,7 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Throttles the noisy, low-value RabbitMQ "Failed to check/redeclare auto-delete queue(s)." error that
  * Spring AMQP logs whenever a listener container races broker readiness on (re)connect. Without throttling a
- * single crash-looping instance can emit tens of thousands of identical events (see Sentry
- * AAM-BACKEND-SERVICE-22, which reached ~47k events from one deployment).
+ * single crash-looping instance can emit tens of thousands of identical events.
  *
  * At most one such event is forwarded to Sentry per [throttleWindow]; the rest are dropped. Keeping a periodic
  * sample means the condition stays visible if it ever recurs after the deployment-level fix, without flooding

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorage.kt
@@ -2,9 +2,11 @@ package com.aamdigital.aambackendservice.reporting.report.sqs
 
 import com.aamdigital.aambackendservice.common.error.AamErrorCode
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
+import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
 import com.aamdigital.aambackendservice.reporting.report.core.QueryStorage
 import org.springframework.core.io.Resource
 import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpResponse
 import org.springframework.web.client.RestClient
 import java.io.InputStream
 
@@ -18,7 +20,18 @@ class SqsQueryStorage(
     private val schemaService: SqsSchemaService
 ) : QueryStorage {
     enum class SqsQueryStorageErrorCode : AamErrorCode {
-        EMPTY_RESPONSE
+        EMPTY_RESPONSE,
+
+        /** SQS rejected the query (4xx) - typically an invalid query in the ReportConfig. */
+        QUERY_FAILED,
+
+        /** SQS failed to execute the query (5xx). */
+        QUERY_EXECUTION_FAILED,
+    }
+
+    companion object {
+        // SQS error bodies are small; cap defensively so we never log/forward an unbounded response
+        private const val MAX_ERROR_BODY_LENGTH = 500
     }
 
     override fun executeQuery(query: QueryRequest): InputStream {
@@ -33,7 +46,22 @@ class SqsQueryStorage(
                 .body(query)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .body(Resource::class.java)
+                // translate transport-level errors into typed AamExceptions that carry the SQS response
+                // body, so an invalid ReportConfig query surfaces with an actionable message instead of an
+                // opaque, untyped HttpClientErrorException
+                .onStatus({ it.is4xxClientError }) { _, clientResponse ->
+                    throw InvalidArgumentException(
+                        message = "[SqsQueryStorage] SQS rejected the query " +
+                            "(${clientResponse.statusCode}): ${readErrorBody(clientResponse)}",
+                        code = SqsQueryStorageErrorCode.QUERY_FAILED,
+                    )
+                }.onStatus({ it.is5xxServerError }) { _, clientResponse ->
+                    throw ExternalSystemException(
+                        message = "[SqsQueryStorage] SQS failed to execute the query " +
+                            "(${clientResponse.statusCode}): ${readErrorBody(clientResponse)}",
+                        code = SqsQueryStorageErrorCode.QUERY_EXECUTION_FAILED,
+                    )
+                }.body(Resource::class.java)
 
         if (response == null) {
             throw ExternalSystemException(
@@ -44,4 +72,9 @@ class SqsQueryStorage(
 
         return response.inputStream
     }
+
+    private fun readErrorBody(response: ClientHttpResponse): String =
+        runCatching {
+            response.body.readBytes().decodeToString().trim().take(MAX_ERROR_BODY_LENGTH)
+        }.getOrDefault("<error body unavailable>")
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
@@ -290,14 +290,18 @@ class DefaultReportCalculationUseCase(
                     InternalServerException(
                         message = exception.localizedMessage,
                         code = ReportCalculationError.UNEXPECTED_ERROR,
-                        cause = exception.cause
+                        // keep `exception` itself, not `exception.cause`: the original error (e.g. the
+                        // HttpClientErrorException from an invalid query) is the root cause we need in Sentry
+                        cause = exception
                     )
             }
 
         return UseCaseOutcome.Failure(
             errorMessage = useCaseException.localizedMessage,
             errorCode = useCaseException.code,
-            cause = useCaseException.cause
+            // propagate the full wrapper chain (useCaseException -> original exception), not just its cause,
+            // so downstream listeners and Sentry receive the complete error trail
+            cause = useCaseException
         )
     }
 

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/webhook/queue/WebhookEventConsumer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/webhook/queue/WebhookEventConsumer.kt
@@ -8,7 +8,6 @@ import com.aamdigital.aambackendservice.reporting.webhook.WebhookEvent
 import com.aamdigital.aambackendservice.reporting.webhook.core.TriggerWebhookUseCase
 import com.aamdigital.aambackendservice.reporting.webhook.di.ReportingNotificationQueueConfiguration.Companion.NOTIFICATION_QUEUE
 import com.rabbitmq.client.Channel
-import io.sentry.Sentry
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.AmqpRejectAndDontRequeueException
 import org.springframework.amqp.core.Message
@@ -55,8 +54,8 @@ class WebhookEventConsumer(
                             ex,
                             code = WebhookError.WEBHOOK_EVENT_TRIGGER_ERROR
                         )
-                    Sentry.captureException(aamEx)
 
+                    // reporting to Sentry is handled centrally by QueueErrorHandler (logs the root cause once)
                     // TODO: requeue to retry (but then we need to make sure to not send an old event after a newer calculation already delivered)
                     throw AmqpRejectAndDontRequeueException(aamEx)
                 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueErrorHandlerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueErrorHandlerTest.kt
@@ -1,0 +1,49 @@
+package com.aamdigital.aambackendservice.common.queue.di
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.AmqpRejectAndDontRequeueException
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException
+
+class QueueErrorHandlerTest {
+    private val handler = QueueErrorHandler()
+    private lateinit var logger: Logger
+    private lateinit var appender: ListAppender<ILoggingEvent>
+
+    @BeforeEach
+    fun setUp() {
+        logger = LoggerFactory.getLogger(QueueErrorHandler::class.java) as Logger
+        appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        logger.detachAppender(appender)
+    }
+
+    @Test
+    fun `logs the unwrapped root cause at ERROR for a wrapped listener failure`() {
+        val rootCause = IllegalStateException("no such column: foo")
+        // mirror how the container wraps a consumer's AmqpRejectAndDontRequeueException
+        val wrapped =
+            ListenerExecutionFailedException(
+                "Listener failed",
+                AmqpRejectAndDontRequeueException("[QUERY_FAILED] rejected", rootCause)
+            )
+
+        // contains an AmqpRejectAndDontRequeueException -> not re-thrown as fatal, just logged + rejected
+        handler.handleError(wrapped)
+
+        val errors = appender.list.filter { it.level == Level.ERROR }
+        assertThat(errors).hasSize(1)
+        assertThat(errors.first().formattedMessage).contains("no such column: foo")
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/queue/di/QueueSentryEventProcessorTest.kt
@@ -1,0 +1,50 @@
+package com.aamdigital.aambackendservice.common.queue.di
+
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import io.sentry.protocol.Message
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.Date
+
+class QueueSentryEventProcessorTest {
+    private val processor = QueueSentryEventProcessor(throttleWindow = Duration.ofMinutes(5))
+
+    private fun redeclareEvent(atEpochMillis: Long): SentryEvent =
+        SentryEvent(Date(atEpochMillis)).apply {
+            message = Message().apply { formatted = REDECLARE_MESSAGE }
+        }
+
+    @Test
+    fun `forwards unrelated events unchanged`() {
+        val event =
+            SentryEvent(Date(0)).apply {
+                message = Message().apply { formatted = "some unrelated error" }
+            }
+
+        assertThat(processor.process(event, Hint())).isSameAs(event)
+    }
+
+    @Test
+    fun `forwards the first redeclare event but drops repeats within the throttle window`() {
+        val first = redeclareEvent(0)
+        val withinWindow = redeclareEvent(Duration.ofMinutes(1).toMillis())
+
+        assertThat(processor.process(first, Hint())).isSameAs(first)
+        assertThat(processor.process(withinWindow, Hint())).isNull()
+    }
+
+    @Test
+    fun `forwards a redeclare event again once the throttle window has elapsed`() {
+        val first = redeclareEvent(0)
+        val afterWindow = redeclareEvent(Duration.ofMinutes(5).toMillis() + 1)
+
+        assertThat(processor.process(first, Hint())).isSameAs(first)
+        assertThat(processor.process(afterWindow, Hint())).isSameAs(afterWindow)
+    }
+
+    companion object {
+        private const val REDECLARE_MESSAGE = "Failed to check/redeclare auto-delete queue(s)."
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
@@ -1,0 +1,66 @@
+package com.aamdigital.aambackendservice.reporting.report.sqs
+
+import com.aamdigital.aambackendservice.common.error.ExternalSystemException
+import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.web.client.RestClient
+
+class SqsQueryStorageTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var storage: SqsQueryStorage
+    private val schemaService: SqsSchemaService = mock()
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val restClient = RestClient.builder().baseUrl(mockWebServer.url("/").toString()).build()
+        whenever(schemaService.getSchemaPath()).thenReturn("/_design/sqs/_view")
+        storage = SqsQueryStorage(restClient, schemaService)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `should return the response stream on success`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""[{"foo":1}]"""))
+
+        val result = storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()))
+
+        assertThat(result.readBytes().decodeToString()).isEqualTo("""[{"foo":1}]""")
+    }
+
+    @Test
+    fun `should throw InvalidArgumentException carrying the SQS body on 4xx (invalid query)`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(400).setBody("no such column: foo"))
+
+        val thrown = catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList())) }
+
+        assertThat(thrown).isInstanceOf(InvalidArgumentException::class.java)
+        assertThat((thrown as InvalidArgumentException).code)
+            .isEqualTo(SqsQueryStorage.SqsQueryStorageErrorCode.QUERY_FAILED)
+        assertThat(thrown.message).contains("no such column: foo")
+    }
+
+    @Test
+    fun `should throw ExternalSystemException on 5xx`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("internal error"))
+
+        val thrown = catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList())) }
+
+        assertThat(thrown).isInstanceOf(ExternalSystemException::class.java)
+        assertThat((thrown as ExternalSystemException).code)
+            .isEqualTo(SqsQueryStorage.SqsQueryStorageErrorCode.QUERY_EXECUTION_FAILED)
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.aamdigital.aambackendservice.reporting.reportcalculation.core
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.domain.TestErrorCode
 import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
+import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.reporting.report.Report
 import com.aamdigital.aambackendservice.reporting.report.ReportItem
@@ -136,6 +137,45 @@ class DefaultReportCalculationUseCaseTest {
                 ReportCalculationError.REPORT_NOT_FOUND
             )
         assertThat(response.cause).isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `should preserve the original error as cause when query execution fails with a non-Aam exception`() {
+        // given
+        val report =
+            Report(
+                id = "Report:1",
+                title = "Report",
+                items = listOf(ReportItem.ReportQuery(sql = "SELECT name FROM foo"))
+            )
+
+        val reportCalculation = getPendingReportCalculation()
+
+        whenever(
+            reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:1")))
+        ).thenReturn(reportCalculation)
+
+        whenever(reportStorage.fetchReport(eq(DomainReference("Report:1")))).thenReturn(report)
+
+        whenever(reportCalculationStorage.storeCalculation(any())).thenAnswer { i -> i.arguments[0] }
+
+        val rootCause = RuntimeException("connection reset")
+        whenever(queryStorage.executeQuery(any())).thenAnswer { throw rootCause }
+
+        // when
+        val response =
+            service.run(
+                ReportCalculationRequest(reportCalculationId = reportCalculation.id)
+            )
+
+        // then
+        assertThat(response).isInstanceOf(UseCaseOutcome.Failure::class.java)
+        val failure = response as UseCaseOutcome.Failure
+        assertThat(failure.errorCode).isEqualTo(ReportCalculationError.UNEXPECTED_ERROR)
+        // regression test for the previous `cause = exception.cause` truncation: the wrapper must keep the
+        // real root cause so it reaches Sentry instead of being dropped
+        assertThat(failure.cause).isInstanceOf(InternalServerException::class.java)
+        assertThat(failure.cause?.cause).isSameAs(rootCause)
     }
 
     @Test


### PR DESCRIPTION
## Background

Sentry [AAM-BACKEND-SERVICE-22](https://aam-digital.sentry.io/issues/AAM-BACKEND-SERVICE-22) (`Failed to check/redeclare auto-delete queue(s).`) reached **~72k occurrences** and was flooding our Sentry quota. The trigger turned out to be **ReportConfigs with invalid queries**: report calculations failed, the failures were reported opaquely (or not at all), and the broker-readiness churn on restarts produced the redeclare bursts. (The deployment-side startup race is addressed separately in ndb-setup #103; this PR hardens the application's error handling.)

While tracing the path, several layers were found to drop or mis-report the real cause.

## Changes

1. **Keep the real cause in `DefaultReportCalculationUseCase.handleException`** — the catch-all branch wrapped `exception.cause` instead of `exception`, and the final `Failure` unwrapped once more, so for a bare error (e.g. the SQS HTTP error) the cause became `null`. Now the full wrapper chain is preserved. *(regression test added)*

2. **Translate SQS transport errors in `SqsQueryStorage`** — `executeQuery` had no `.onStatus` handler, so an invalid query surfaced as an opaque `HttpClientErrorException`. Now 4xx → `InvalidArgumentException(QUERY_FAILED)` and 5xx → `ExternalSystemException(QUERY_EXECUTION_FAILED)`, each carrying the (capped) SQS response body so the broken report is identifiable.

3. **Fix the dead `QueueSentryEventProcessor`** — it compared `event.message?.toString()`, but `io.sentry.protocol.Message` does **not** override `toString()`, so the check never matched and the processor was a **silent no-op** (the real reason all events reached Sentry). Now it matches on `Message.formatted` and throttles to **one event per window** (default `PT5M`, configurable), thread-safe via an `AtomicReference`.

4. **Central listener error handling (`QueueErrorHandler`)** — rejected messages were only logged at WARN (below Sentry's event level), and just one consumer reported to Sentry by hand. A `ConditionalRejectingErrorHandler` on the listener container factory now logs the **unwrapped root cause at ERROR once** for every permanent failure (consistent Sentry coverage + grouping), the redundant `Sentry.captureException` in `WebhookEventConsumer` is removed, and `DomainUseCase`'s failure log is raised from debug → warn. The factory is rebuilt via `SimpleRabbitListenerContainerFactoryConfigurer`, so all existing retry/recoverer/converter wiring is preserved.

## Validation

- New/updated unit tests: cause-chain regression, `SqsQueryStorage` 4xx/5xx translation, throttle-window behaviour, root-cause logging.
- Full suite green locally, incl. `CucumberTestRunner` (52 e2e tests) — confirms the new container-factory bean loads the application context cleanly.
- All changed/added files are ktlint-clean.

## Intentional behaviour change

Permanent queue failures (e.g. report-calc failures from bad queries) now consistently reach Sentry as ERROR events grouped by root cause — previously most were invisible. This is deliberate (it's how we find broken ReportConfigs). If volume becomes a concern, the upstream fix is validating ReportConfig SQL at save time.

## Out of scope (follow-ups)

- `RestClient.body(Resource)` buffering / OOM risk on huge query results (the likely crash-loop bridge) + container `mem_limit`.
- Validating ReportConfig SQL at write time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for SQS query failures with more specific error types and capped error messages.
  * Enhanced centralized queue error handling with better logging for listener failures.
  * Refined exception propagation in report calculations for improved error visibility.

* **Chores**
  * Implemented time-based throttling for duplicate error events in error reporting to reduce notification noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->