### PR TITLE
fix(notification): move config for email subject to template folder

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/templating/LocalizedTemplateLoader.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/templating/LocalizedTemplateLoader.kt
@@ -1,0 +1,91 @@
+package com.aamdigital.aambackendservice.common.templating
+
+import org.slf4j.LoggerFactory
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Loads locale-specific, deployment-overridable template resources (email bodies, branding text,
+ * etc.) using a single, shared resolution order. Centralizing this here keeps the order and the
+ * `{locale}` / mounted-override / bundled-classpath path conventions in one place so every template
+ * (the email HTML body, the email branding properties, and any future template) resolves
+ * identically.
+ *
+ * Templates live under a per-language folder (`{locale}/...`) so a translator can copy a whole
+ * language folder (e.g. `en/` -> `de/`) and translate it. Operators can override the bundled
+ * defaults by mounting their own files under [templatesBaseDir] (e.g. `/opt/app/templates`).
+ *
+ * @param templatesBaseDir directory holding mounted override templates.
+ * @param defaultLocale base language used as the final fallback (`en`).
+ * @param classpathRoot root folder of the bundled templates on the classpath (`templates`).
+ */
+class LocalizedTemplateLoader(
+    private val templatesBaseDir: Path,
+    private val defaultLocale: String = DEFAULT_LOCALE,
+    private val classpathRoot: String = TEMPLATES_CLASSPATH_ROOT
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Resolves the resource at [relativePath] (e.g. `notification/email-branding.properties`) for
+     * the given [locale], trying, in order, and returning the content of the first that exists (or
+     * `null` if none do):
+     *  1. mounted override, localized: `{baseDir}/{locale}/{relativePath}`
+     *  2. mounted override, legacy unsuffixed (back-compat): `{baseDir}/{relativePath}`
+     *  3. bundled classpath, localized: `/{classpathRoot}/{locale}/{relativePath}`
+     *  4. bundled classpath, default language: `/{classpathRoot}/{defaultLocale}/{relativePath}`
+     *
+     * A region suffix in [locale] is ignored (`de-DE` -> `de`); a blank locale falls back to
+     * [defaultLocale].
+     */
+    fun load(relativePath: String, locale: String): String? {
+        val normalizedLocale = normalizeLocale(locale)
+
+        val localizedOverride = templatesBaseDir.resolve(normalizedLocale).resolve(relativePath)
+        if (Files.isRegularFile(localizedOverride)) {
+            logger.info("Loading template resource from {}", localizedOverride)
+            return Files.readString(localizedOverride, StandardCharsets.UTF_8)
+        }
+
+        val legacyOverride = templatesBaseDir.resolve(relativePath)
+        if (Files.isRegularFile(legacyOverride)) {
+            logger.info("Loading template resource from legacy override {}", legacyOverride)
+            return Files.readString(legacyOverride, StandardCharsets.UTF_8)
+        }
+
+        readClasspathResource("/$classpathRoot/$normalizedLocale/$relativePath")?.let { return it }
+
+        return readClasspathResource("/$classpathRoot/$defaultLocale/$relativePath")
+    }
+
+    /**
+     * Like [load] but throws when the resource cannot be resolved anywhere — for templates that
+     * must always exist (a bundled classpath default is expected).
+     */
+    fun loadRequired(relativePath: String, locale: String): String =
+        load(relativePath, locale)
+            ?: throw IllegalStateException(
+                "Missing template resource: /$classpathRoot/$defaultLocale/$relativePath"
+            )
+
+    private fun readClasspathResource(classpathLocation: String): String? {
+        javaClass.getResourceAsStream(classpathLocation)?.use { resource ->
+            logger.info("Loading template resource from classpath {}", classpathLocation)
+            return resource.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        }
+        return null
+    }
+
+    /**
+     * Reduces a (possibly region-qualified) locale to the base language code used for the template
+     * folder name, e.g. `en-US` -> `en`, `de_DE` -> `de`. Falls back to [defaultLocale] for blank input.
+     */
+    private fun normalizeLocale(locale: String): String =
+        locale.substringBefore('-').substringBefore('_').trim().lowercase().ifBlank { defaultLocale }
+
+    companion object {
+        const val DEFAULT_LOCALE = "en"
+        const val TEMPLATES_CLASSPATH_ROOT = "templates"
+    }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/core/create/email/EmailCreateNotificationHandler.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/core/create/email/EmailCreateNotificationHandler.kt
@@ -3,6 +3,7 @@ package com.aamdigital.aambackendservice.notification.core.create.email
 import com.aamdigital.aambackendservice.common.mail.MailSenderRequest
 import com.aamdigital.aambackendservice.common.mail.MailSenderService
 import com.aamdigital.aambackendservice.common.domain.normalizeUrlWithHttpsDefault
+import com.aamdigital.aambackendservice.common.templating.LocalizedTemplateLoader
 import com.aamdigital.aambackendservice.notification.core.CreateUserNotificationEvent
 import com.aamdigital.aambackendservice.notification.core.create.CreateNotificationData
 import com.aamdigital.aambackendservice.notification.core.create.CreateNotificationHandler
@@ -14,20 +15,24 @@ import org.springframework.mail.MailSendException
 import org.springframework.web.util.HtmlUtils
 import java.net.ConnectException
 import java.net.SocketTimeoutException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.nio.charset.StandardCharsets
+import java.io.StringReader
+import java.util.Properties
 
 class EmailCreateNotificationHandler(
     private val mailSenderService: MailSenderService,
     private val userEmailProvider: UserEmailProvider,
     private val notificationEmailProperties: NotificationEmailProperties,
-    private val templatesBaseDir: Path = DEFAULT_TEMPLATES_BASE_DIR
+    templatesBaseDir: Path = DEFAULT_TEMPLATES_BASE_DIR
 ) : CreateNotificationHandler {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val emailBodyTemplate: String = loadEmailBodyTemplate(normalizeLocale(notificationEmailProperties.locale))
+    private val templateLoader = LocalizedTemplateLoader(templatesBaseDir)
+    private val emailBodyTemplate: String =
+        templateLoader.loadRequired(TEMPLATE_RELATIVE_PATH, notificationEmailProperties.locale)
+    private val branding: EmailBranding = loadEmailBranding(notificationEmailProperties.locale)
     private val normalizedManageSettingsUrl: String = normalizeUrlWithHttpsDefault(notificationEmailProperties.manageSettingsUrl)
+    private val resolvedFrom: String = resolveFrom(notificationEmailProperties.from, branding.fromName)
 
     override fun canHandle(notificationChannelType: NotificationChannelType): Boolean =
         NotificationChannelType.EMAIL == notificationChannelType
@@ -43,7 +48,7 @@ class EmailCreateNotificationHandler(
         }
 
         val details = createUserNotificationEvent.details
-        val subject = "${notificationEmailProperties.subjectPrefix}: ${details.title}"
+        val subject = "${branding.subjectPrefix}: ${details.title}"
         val body =
             buildEmailBody(
                 title = details.title,
@@ -58,7 +63,7 @@ class EmailCreateNotificationHandler(
                         to = email,
                         subject = subject,
                         body = body,
-                        from = notificationEmailProperties.from,
+                        from = resolvedFrom,
                         isHtml = true,
                         headers =
                             mapOf(
@@ -102,54 +107,55 @@ class EmailCreateNotificationHandler(
             .replace("{{MANAGE_SETTINGS_URL}}", HtmlUtils.htmlEscape(manageSettingsUrl))
 
     /**
-     * Reduces a (possibly region-qualified) locale to the base language code used
-     * for the template folder name, e.g. `en-US` -> `en`, `de_DE` -> `de`.
-     * Falls back to [DEFAULT_LOCALE] for blank input.
+     * Composes the final sender header from the deployment-specific address
+     * ([NotificationEmailProperties.from]) and the [fromName] display text managed in the
+     * branding file, e.g. `Aam Digital <notifications@example.org>`.
+     *
+     * Falls back to the bare configured address when no [fromName] is configured (or the address
+     * is empty).
      */
-    private fun normalizeLocale(locale: String): String =
-        locale.substringBefore('-').substringBefore('_').trim().lowercase().ifBlank { DEFAULT_LOCALE }
-
-    /**
-     * Resolves the email template for the given (normalized) locale, trying, in order:
-     *  1. mounted override, localized: `{baseDir}/{locale}/notification/...`
-     *  2. mounted override, legacy unsuffixed (back-compat): `{baseDir}/notification/...`
-     *  3. bundled classpath, localized: `/templates/{locale}/notification/...`
-     *  4. bundled classpath, default English: `/templates/en/notification/...`
-     */
-    private fun loadEmailBodyTemplate(locale: String): String {
-        val localizedOverride = templatesBaseDir.resolve(locale).resolve(TEMPLATE_RELATIVE_PATH)
-        if (Files.isRegularFile(localizedOverride)) {
-            logger.info("Loading notification email template from {}", localizedOverride)
-            return Files.readString(localizedOverride, StandardCharsets.UTF_8)
+    private fun resolveFrom(configuredFrom: String, fromName: String): String {
+        val address = configuredFrom.trim()
+        if (address.isEmpty() || fromName.isBlank()) {
+            return configuredFrom
         }
-
-        val legacyOverride = templatesBaseDir.resolve(TEMPLATE_RELATIVE_PATH)
-        if (Files.isRegularFile(legacyOverride)) {
-            logger.info("Loading notification email template from legacy override {}", legacyOverride)
-            return Files.readString(legacyOverride, StandardCharsets.UTF_8)
-        }
-
-        val localizedClasspath = "/$TEMPLATES_CLASSPATH_ROOT/$locale/$TEMPLATE_RELATIVE_PATH"
-        javaClass.getResourceAsStream(localizedClasspath)?.use { resource ->
-            logger.info("Loading notification email template from classpath {}", localizedClasspath)
-            return resource.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
-        }
-
-        val defaultClasspath = "/$TEMPLATES_CLASSPATH_ROOT/$DEFAULT_LOCALE/$TEMPLATE_RELATIVE_PATH"
-        val resource = javaClass.getResourceAsStream(defaultClasspath)
-            ?: throw IllegalStateException("Missing email template resource: $defaultClasspath")
-
-        logger.info("Loading notification email template from classpath fallback {}", defaultClasspath)
-        return resource
-            .bufferedReader(StandardCharsets.UTF_8)
-            .use { it.readText() }
+        return "$fromName <$address>"
     }
 
+    /**
+     * Loads the email branding text (sender display name, subject prefix) for the given locale via
+     * the shared [templateLoader]. Missing file or keys fall back to [DEFAULT_SUBJECT_PREFIX] / no
+     * display name.
+     */
+    private fun loadEmailBranding(locale: String): EmailBranding {
+        val properties = Properties()
+        val content = templateLoader.load(BRANDING_RELATIVE_PATH, locale)
+        if (content != null) {
+            properties.load(StringReader(content))
+        } else {
+            logger.warn("No notification email branding file found; using defaults")
+        }
+        return EmailBranding(
+            fromName = properties.getProperty("from-name", "").trim(),
+            subjectPrefix = properties.getProperty("subject-prefix", DEFAULT_SUBJECT_PREFIX).trim()
+        )
+    }
+
+    /**
+     * Branding text for notification emails, managed in the `email-branding.properties` template
+     * file rather than in deployment config.
+     */
+    private data class EmailBranding(
+        val fromName: String,
+        val subjectPrefix: String
+    )
+
     companion object {
-        private const val DEFAULT_LOCALE = "en"
-        private const val TEMPLATES_CLASSPATH_ROOT = "templates"
+        private const val DEFAULT_SUBJECT_PREFIX = "Aam Digital"
         private const val TEMPLATE_RELATIVE_PATH =
             "notification/create-notification-email-template.html"
+        private const val BRANDING_RELATIVE_PATH =
+            "notification/email-branding.properties"
         private val DEFAULT_TEMPLATES_BASE_DIR: Path =
             Paths.get("/opt/app/templates")
     }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationEmailProperties.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationEmailProperties.kt
@@ -9,17 +9,13 @@ data class NotificationEmailProperties(
     /**
      * Sender email address for outgoing notification emails.
      *
+     * This is the deployment-specific address only; the display name shown in front of it (and the
+     * subject prefix) are managed in the `email-branding.properties` template file.
+     *
      * Expected format: RFC-5322 compliant email address.
      * Default value: empty string (`""`).
      */
     val from: String = "",
-    /**
-     * Prefix prepended to outgoing notification email subjects.
-     *
-     * Expected format: plain string.
-     * Default value: `"Aam Digital"`.
-     */
-    val subjectPrefix: String = "Aam Digital",
     /**
      * URL where users can manage their notification settings.
      *

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -73,8 +73,9 @@ features:
 
 notification:
   email:
+    # Sender address only; the display name and subject prefix are managed in the
+    # templates/{locale}/notification/email-branding.properties template file.
     from: ""
-    subject-prefix: Aam Digital
     manage-settings-url: "${application.base-url}/user-account?tabIndex=1"
     # Deployment-wide language for the email boilerplate (e.g. en, de, fr).
     # Selects the bundled/overridden template under {locale}/notification/...

--- a/application/aam-backend-service/src/main/resources/templates/en/notification/email-branding.properties
+++ b/application/aam-backend-service/src/main/resources/templates/en/notification/email-branding.properties
@@ -1,0 +1,15 @@
+# Branding text for outgoing notification emails (English / default locale).
+#
+# Kept here, alongside the email HTML templates, so all template-related text is managed in one
+# place instead of being spread across env vars / application.yaml. Resolved per locale just like
+# the HTML template: a {locale}/notification/email-branding.properties is used when present,
+# otherwise this English copy is the fallback. To customize per deployment, mount your own copy at
+# /opt/app/templates/{locale}/notification/email-branding.properties (the same override mechanism
+# used for the email HTML templates).
+
+# Display name shown in front of the sender address, e.g. "Aam Digital <notifications@example.org>".
+# The address itself is deployment-specific and stays in config (notification.email.from).
+from-name=Aam Digital
+
+# Prefix prepended to every notification email subject, e.g. "Aam Digital: A new record was added".
+subject-prefix=Aam Digital

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/notification/core/create/email/EmailCreateNotificationHandlerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/notification/core/create/email/EmailCreateNotificationHandlerTest.kt
@@ -46,7 +46,6 @@ class EmailCreateNotificationHandlerTest {
     private val emailProperties =
         NotificationEmailProperties(
             from = "noreply@example.com",
-            subjectPrefix = "Aam Digital",
             manageSettingsUrl = "https://app.test/user-account"
         )
 
@@ -94,6 +93,23 @@ class EmailCreateNotificationHandlerTest {
             }
         Files.createDirectories(dir)
         val file = dir.resolve("create-notification-email-template.html")
+        Files.writeString(file, content, StandardCharsets.UTF_8)
+        return file
+    }
+
+    /**
+     * Writes a branding override under [baseDir]. A [locale] of `null` writes the legacy
+     * unsuffixed location `{baseDir}/notification/...`; otherwise `{baseDir}/{locale}/notification/...`.
+     */
+    private fun writeBrandingOverride(baseDir: Path, locale: String?, content: String): Path {
+        val dir =
+            if (locale == null) {
+                baseDir.resolve("notification")
+            } else {
+                baseDir.resolve(locale).resolve("notification")
+            }
+        Files.createDirectories(dir)
+        val file = dir.resolve("email-branding.properties")
         Files.writeString(file, content, StandardCharsets.UTF_8)
         return file
     }
@@ -357,6 +373,111 @@ class EmailCreateNotificationHandlerTest {
         val requestCaptor = argumentCaptor<MailSenderRequest>()
         verify(mailSenderService).sendMail(requestCaptor.capture())
         assertThat(requestCaptor.firstValue.body).contains("In Aam Digital öffnen")
+    }
+
+    @Test
+    fun `should compose from header with the bundled branding display name`() {
+        // Given the configured 'from' is a bare address and no branding override exists,
+        // the bundled email-branding.properties supplies the display name "Aam Digital".
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("Aam Digital <noreply@example.com>")
+    }
+
+    @Test
+    fun `should use bare configured from when branding has no display name`() {
+        // Given a branding override that omits the display name
+        writeBrandingOverride(tempDir, locale = "en", content = "subject-prefix=Custom")
+        handler = createHandler(templatesBaseDir = tempDir, locale = "en")
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("noreply@example.com")
+    }
+
+    @Test
+    fun `should apply branding override for display name and subject prefix`() {
+        // Given a mounted branding override
+        writeBrandingOverride(tempDir, locale = "en", content = "from-name=Custom Brand\nsubject-prefix=Custom")
+        handler = createHandler(templatesBaseDir = tempDir, locale = "en")
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("Custom Brand <noreply@example.com>")
+        assertThat(requestCaptor.firstValue.subject).startsWith("Custom:")
+    }
+
+    @Test
+    fun `should apply localized branding override matching the configured locale`() {
+        // Given both an English and a German branding override exist, configured locale is German
+        writeBrandingOverride(tempDir, locale = "en", content = "from-name=English Brand\nsubject-prefix=English")
+        writeBrandingOverride(tempDir, locale = "de", content = "from-name=Deutsche Marke\nsubject-prefix=Deutsch")
+        handler = createHandler(templatesBaseDir = tempDir, locale = "de")
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("Deutsche Marke <noreply@example.com>")
+        assertThat(requestCaptor.firstValue.subject).startsWith("Deutsch:")
+    }
+
+    @Test
+    fun `should apply legacy unsuffixed branding override as backward-compatible fallback`() {
+        // Given only a legacy unsuffixed branding override exists and the locale folder is absent
+        writeBrandingOverride(tempDir, locale = null, content = "from-name=Legacy Brand\nsubject-prefix=Legacy")
+        handler = createHandler(templatesBaseDir = tempDir, locale = "de")
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("Legacy Brand <noreply@example.com>")
+        assertThat(requestCaptor.firstValue.subject).startsWith("Legacy:")
+    }
+
+    @Test
+    fun `should fall back to English bundled branding for a locale without a branding file`() {
+        // Given no overrides and a configured locale (es) that has no bundled branding file
+        handler = createHandler(templatesBaseDir = tempDir, locale = "es")
+        whenever(userEmailProvider.lookupEmail("user-123")).thenReturn("user@example.com")
+        whenever(mailSenderService.sendMail(any())).thenReturn(MailSenderResponse(success = true))
+
+        // When
+        handler.createMessage(notificationEvent)
+
+        // Then the bundled English branding ("Aam Digital") is used
+        val requestCaptor = argumentCaptor<MailSenderRequest>()
+        verify(mailSenderService).sendMail(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.from).isEqualTo("Aam Digital <noreply@example.com>")
+        assertThat(requestCaptor.firstValue.subject).startsWith("Aam Digital:")
     }
 
     @Test

--- a/docs/modules/notification.md
+++ b/docs/modules/notification.md
@@ -52,7 +52,9 @@ FEATURES_NOTIFICATIONAPI_MODE=firebase    # delivery mode for push notifications
 FEATURES_NOTIFICATIONAPI_EMAIL_ENABLED=false  # set true to enable email notifications
 
 # Required for email notifications (SMTP)
-NOTIFICATION_EMAIL_FROM="Aam Digital <notifications@your-instance.org>"
+# Sender address only; the display name and subject prefix are managed in the
+# templates/{locale}/notification/email-branding.properties template file.
+NOTIFICATION_EMAIL_FROM=notifications@your-instance.org
 SPRING_MAIL_HOST=<smtp-host>
 SPRING_MAIL_PORT=587
 SPRING_MAIL_USERNAME=<smtp-username>
@@ -60,8 +62,6 @@ SPRING_MAIL_PASSWORD=<smtp-password>
 SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
 SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=true
 
-# Recommended for email notifications (email content)
-NOTIFICATION_EMAIL_SUBJECTPREFIX=Aam Digital
 # Language of the email boilerplate (en, de, fr). Defaults to en.
 # Keep in sync with the site default language.
 NOTIFICATION_EMAIL_LOCALE=en
@@ -139,6 +139,7 @@ volumes:
 ```text
 config/aam-backend-service/templates/
   de/notification/create-notification-email-template.html
+  de/notification/email-branding.properties
   fr/notification/create-notification-email-template.html
 ```
 
@@ -147,6 +148,36 @@ Important:
 - Template changes require a container restart.
 - The backend does not manage logo files or inline image attachments.
   Template authors can embed images directly in the HTML template (for example as data URIs or remote image URLs).
+
+### Email Branding (sender name & subject prefix)
+
+The sender display name and the subject prefix are **not** environment variables. They are kept
+together with the email templates in `{locale}/notification/email-branding.properties`, so all
+template-related text is managed in one place:
+
+```properties
+# Display name shown in front of the sender address, e.g. "Aam Digital <notifications@example.org>".
+from-name=Aam Digital
+# Prefix prepended to every notification email subject, e.g. "Aam Digital: A new record was added".
+subject-prefix=Aam Digital
+```
+
+- `from-name` is combined with the configured address (`NOTIFICATION_EMAIL_FROM`, which holds the
+  bare address only) to form the final sender header `from-name <NOTIFICATION_EMAIL_FROM>`. If
+  `from-name` is empty, the bare address is used as-is.
+- `subject-prefix` is prepended to every email subject.
+
+The file is resolved per locale (`NOTIFICATION_EMAIL_LOCALE`) using the **same order as the HTML
+template**, using the first that exists:
+
+1. Mounted override, localized: `/opt/app/templates/{locale}/notification/email-branding.properties`
+2. Mounted override, legacy unsuffixed: `/opt/app/templates/notification/email-branding.properties`
+3. Bundled classpath, localized: `src/main/resources/templates/{locale}/notification/email-branding.properties`
+4. Bundled classpath, English fallback: `src/main/resources/templates/en/notification/email-branding.properties`
+
+Only the English (`en`) branding file is bundled; other locales fall back to it unless you provide a
+localized copy (e.g. to translate the subject prefix). If the file — or an individual key — is
+missing, the subject prefix falls back to `Aam Digital` and no display name is added.
 
 ### Permission-Aware Notifications (optional)
 

--- a/templates/aam-backend-service/application.template.env
+++ b/templates/aam-backend-service/application.template.env
@@ -17,8 +17,9 @@ FEATURES_EXPORTAPI_ENABLED=true
 FEATURES_NOTIFICATIONAPI_ENABLED=false
 FEATURES_NOTIFICATIONAPI_MODE=firebase
 FEATURES_NOTIFICATIONAPI_EMAIL_ENABLED=false
-NOTIFICATION_EMAIL_FROM="Aam Digital <notifications@your-instance.org>"
-NOTIFICATION_EMAIL_SUBJECTPREFIX=Aam Digital
+# Sender address only. The display name in front of it and the subject prefix are managed in the
+# templates/{locale}/notification/email-branding.properties file (mount an override to customize per deployment).
+NOTIFICATION_EMAIL_FROM=notifications@your-instance.org
 SPRING_MAIL_HOST=
 SPRING_MAIL_PORT=
 SPRING_MAIL_USERNAME=


### PR DESCRIPTION
for easier override in deployments, to avoid having to configure both env vars and a template volume to customize the email feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language-specific email branding support, enabling customization of sender display name and email subject prefix per language with automatic fallback to English

* **Documentation**
  * Updated email configuration documentation with details on managing language-specific email branding properties and template resolution order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->