### PR TITLE
feat(features): report audit (change-logging) feature via /actuator/features

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/audit/AuditFeatureInfoEndpoint.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/audit/AuditFeatureInfoEndpoint.kt
@@ -1,0 +1,26 @@
+package com.aamdigital.aambackendservice.audit
+
+import com.aamdigital.aambackendservice.common.actuator.FeatureRegistrar
+import com.aamdigital.aambackendservice.common.actuator.FeaturesInfoDto
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * Reports the "audit" (change-logging) feature via `/actuator/features` so the
+ * frontend can show/hide the change-history UI accordingly.
+ *
+ * Note: the audit feature itself is implemented in the replication-backend
+ * (its `AUDIT_ENABLED` flag). This flag only mirrors that for the frontend, so
+ * `features.audit.enabled` (env `FEATURES_AUDIT_ENABLED`) must be kept in sync
+ * with the replication-backend's `AUDIT_ENABLED`.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "features.audit",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false
+)
+class AuditFeatureInfoEndpoint : FeatureRegistrar {
+    override fun getFeatureInfo(): Pair<String, FeaturesInfoDto> = "audit" to FeaturesInfoDto(true)
+}

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -70,6 +70,9 @@ features:
       enabled: false
   third-party-authentication:
     enabled: false
+  # mirrors the replication-backend's AUDIT_ENABLED (env FEATURES_AUDIT_ENABLED)
+  audit:
+    enabled: false
 
 notification:
   email:
@@ -201,6 +204,8 @@ features:
     email:
       enabled: true
   third-party-authentication:
+    enabled: true
+  audit:
     enabled: true
 
 keycloak:


### PR DESCRIPTION
Adds an `AuditFeatureInfoEndpoint` that registers the **audit** (change-logging) feature in `/actuator/features`, so the frontend can show/hide the change-history UI based on whether change logging is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit feature flag that can be enabled or disabled via configuration settings
  * Audit feature status is now exposed through the features endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->