### PR TITLE
fix(reporting): revert to data format according to API v1 specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,7 +435,7 @@ Run only the e2e tests (skips unit tests):
 ./gradlew test --tests "*CucumberTestRunner"
 ```
 
-Gradle caches passing tests — a re-run with no source changes is reported `UP-TO-DATE` and does nothing. Prefix `cleanTest` to force it: `./gradlew cleanTest test --tests "*CucumberTestRunner"`.
+Gradle caches passing tests — a re-run with no source changes is reported `UP-TO-DATE` and does nothing. Prefix `clean` to force it: `./gradlew clean test --tests "*CucumberTestRunner"`.
 
 Filter to specific scenarios with environment variables (always keep `--tests "*CucumberTestRunner"` to skip unit tests):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,9 +425,19 @@ For local development setup (databases, queues, Keycloak), see `docs/developer/R
 ./gradlew test --tests "com.aamdigital.aambackendservice.export.usecase.DefaultCreateTemplateUseCaseTest"
 ```
 
-### Running Specific Cucumber (E2E) Tests
+### Running the E2E (Cucumber) Tests
 
-Use environment variables to filter Cucumber scenarios. Always combine with `--tests "*CucumberTestRunner"` to skip unit tests.
+Prerequisites: JDK 21 and a running Docker daemon (Testcontainers starts/stops the containers itself).
+
+Run only the e2e tests (skips unit tests):
+
+```bash
+./gradlew test --tests "*CucumberTestRunner"
+```
+
+Gradle caches passing tests — a re-run with no source changes is reported `UP-TO-DATE` and does nothing. Prefix `cleanTest` to force it: `./gradlew cleanTest test --tests "*CucumberTestRunner"`.
+
+Filter to specific scenarios with environment variables (always keep `--tests "*CucumberTestRunner"` to skip unit tests):
 
 ```bash
 # By tag — add e.g. @Focus to the scenario in the .feature file, then filter
@@ -443,7 +453,7 @@ CUCUMBER_FILTER_NAME="client makes call to start a report calculation" ./gradlew
 CUCUMBER_FEATURES="src/test/resources/cucumber/features/notification/notification-change-type.feature:8" ./gradlew test --tests "*CucumberTestRunner"
 ```
 
-Note: Cucumber E2E tests use Testcontainers, so Docker must be running. Container startup adds ~30-60s overhead regardless of how many scenarios run.
+Note: booting the full container stack + Spring Boot adds ~1–2 min of overhead before the first scenario runs, regardless of how many scenarios you select.
 
 ### Working with Test Results
 

--- a/README.md
+++ b/README.md
@@ -89,23 +89,43 @@ The test suite includes:
 - **Unit tests** (JUnit 5 + Mockito) for individual use cases and services
 - **E2E / integration tests** (Cucumber BDD) that spin up real Docker containers via Testcontainers (Keycloak, CouchDB, PostgreSQL, RabbitMQ, Carbone, SQS) and test full API flows. Cucumber feature files are located in `src/test/resources/cucumber/features/`.
 
-Both run together with `./gradlew test` — Docker must be available for the e2e tests.
+Both run together with `./gradlew test`.
 
-### Running a specific Cucumber scenario
+### Running the e2e tests
 
-You can run individual Cucumber scenarios using environment variables to filter by tag, feature file, or scenario name:
+**Prerequisites:** JDK 21 and a **running Docker daemon** — Testcontainers starts
+and tears down all the containers itself, so no other local setup (no
+docker-compose, no manual Keycloak) is needed.
+
+Run **only** the e2e tests (skips the unit tests):
+
+```shell
+./gradlew test --tests "*CucumberTestRunner"
+```
+
+Booting the full container stack and Spring Boot takes **~1–2 minutes** before the
+first scenario runs, regardless of how many scenarios you select.
+
+> **Gradle caches passing tests.** If you re-run without changing any source, the
+> `test` task reports `UP-TO-DATE` and nothing actually executes. Force a re-run
+> by prefixing `cleanTest`, e.g. `./gradlew cleanTest test --tests "*CucumberTestRunner"`.
+
+#### Running specific scenarios
+
+Filter scenarios with environment variables (always keep `--tests "*CucumberTestRunner"`
+so the unit tests stay skipped):
 
 ```shell
 # By tag (add e.g. @Focus to the scenario in the .feature file)
 CUCUMBER_FILTER_TAGS="@Focus" ./gradlew test --tests "*CucumberTestRunner"
 
-# By feature file path
+# By an existing tag (e.g. @Notification)
 CUCUMBER_FILTER_TAGS="@Notification" ./gradlew test --tests "*CucumberTestRunner"
 
 # By scenario name (regex)
 CUCUMBER_FILTER_NAME="client makes call to start a report calculation" ./gradlew test --tests "*CucumberTestRunner"
 
-# By feature file path with line number for a single scenario
+# By feature file path (optionally with :line for a single scenario)
 CUCUMBER_FEATURES="src/test/resources/cucumber/features/notification/notification-change-type.feature:8" ./gradlew test --tests "*CucumberTestRunner"
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ first scenario runs, regardless of how many scenarios you select.
 
 > **Gradle caches passing tests.** If you re-run without changing any source, the
 > `test` task reports `UP-TO-DATE` and nothing actually executes. Force a re-run
-> by prefixing `cleanTest`, e.g. `./gradlew cleanTest test --tests "*CucumberTestRunner"`.
+> by prefixing `clean`, e.g. `./gradlew clean test --tests "*CucumberTestRunner"`.
 
 #### Running specific scenarios
 

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
@@ -109,15 +109,32 @@ class DefaultReportCalculationUseCase(
             handleTransformations(argKey, transformationKeys, reportCalculation.args)
         }
 
+        // A single top-level query returns its rows directly as a flat JSON array ([{…},{…}]),
+        // matching the documented ReportData schema that external consumers (e.g. TolaData) rely on.
+        // Only reports with multiple items / groups get an enclosing array so each item's result
+        // stays addressable as data[i]; wrapping a single query in that extra array would collapse
+        // the result to a single row of nested objects for those flat consumers.
+        val singleBareQuery =
+            report.items.size == 1 && report.items.first() is ReportItem.ReportQuery
+
         val resultData =
-            listOf(
-                "[".byteInputStream(),
-                handleReportItems(
-                    queries = report.items,
-                    reportCalculation = reportCalculation
-                ),
-                "]".byteInputStream()
-            )
+            if (singleBareQuery) {
+                listOf(
+                    handleReportItems(
+                        queries = report.items,
+                        reportCalculation = reportCalculation
+                    )
+                )
+            } else {
+                listOf(
+                    "[".byteInputStream(),
+                    handleReportItems(
+                        queries = report.items,
+                        reportCalculation = reportCalculation
+                    ),
+                    "]".byteInputStream()
+                )
+            }
 
         val result =
             reportCalculationStorage.addReportCalculationData(

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberTestRunner.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberTestRunner.kt
@@ -5,5 +5,5 @@ import io.cucumber.junit.CucumberOptions
 import org.junit.runner.RunWith
 
 @RunWith(Cucumber::class)
-@CucumberOptions(features = ["src/test/resources"], tags = "not @Disabled")
+@CucumberOptions(features = ["src/test/resources"])
 class CucumberTestRunner

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
@@ -273,7 +273,7 @@ class DefaultReportCalculationUseCaseTest {
                         ReportItem.ReportQuery(
                             sql =
                                 "SELECT *, json_extract(foo.children, '\$[0]') FROM foo " +
-                                    "WHERE time BETWEEN \$startDate and \$endDate"
+                                        "WHERE time BETWEEN \$startDate and \$endDate"
                         )
                     ),
                 transformations =
@@ -357,7 +357,7 @@ class DefaultReportCalculationUseCaseTest {
                         ReportItem.ReportQuery(
                             sql =
                                 "SELECT * FROM foo WHERE time BETWEEN \$startDate and \$endDate " +
-                                    "AND date BETWEEN \$startDate AND \$endDate"
+                                        "AND date BETWEEN \$startDate AND \$endDate"
                         )
                     ),
                 transformations =
@@ -675,7 +675,7 @@ class DefaultReportCalculationUseCaseTest {
 
         // then: a single bare query returns its rows directly, matching the documented ReportData
         // schema (a flat array of row objects) that external consumers such as TolaData rely on
-        assertEquals("""[{"name":"Alice"},{"name":"Bob"}]""", storedData)
+        assertThat(storedData).isEqualTo("""[{"name":"Alice"},{"name":"Bob"}]""")
     }
 
     @Test
@@ -717,6 +717,6 @@ class DefaultReportCalculationUseCaseTest {
         service.run(ReportCalculationRequest(reportCalculationId = reportCalculation.id))
 
         // then: multiple items stay wrapped so each item's result remains addressable as data[i]
-        assertEquals("""[[{"name":"Alice"}],[{"age":5}]]""", storedData)
+        assertThat(storedData).isEqualTo("""[[{"name":"Alice"}],[{"age":5}]]""")
     }
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
@@ -29,6 +29,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.InputStream
 
 @ExtendWith(MockitoExtension::class)
 class DefaultReportCalculationUseCaseTest {
@@ -639,5 +640,83 @@ class DefaultReportCalculationUseCaseTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `should store a single-query report as a flat array of rows without extra wrapping`() {
+        // given
+        val report =
+            Report(
+                id = "Report:1",
+                title = "Report",
+                items = listOf(ReportItem.ReportQuery(sql = "SELECT name FROM foo"))
+            )
+        val reportCalculation = getPendingReportCalculation()
+
+        whenever(
+            reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:1")))
+        ).thenReturn(reportCalculation)
+
+        whenever(reportStorage.fetchReport(eq(DomainReference("Report:1")))).thenReturn(report)
+
+        whenever(queryStorage.executeQuery(any()))
+            .thenReturn("""[{"name":"Alice"},{"name":"Bob"}]""".byteInputStream())
+
+        whenever(reportCalculationStorage.storeCalculation(any())).thenAnswer { i -> i.arguments[0] }
+
+        var storedData: String? = null
+        whenever(reportCalculationStorage.addReportCalculationData(any(), any())).thenAnswer { i ->
+            storedData = (i.arguments[1] as InputStream).readBytes().decodeToString()
+            i.arguments[0]
+        }
+
+        // when
+        service.run(ReportCalculationRequest(reportCalculationId = reportCalculation.id))
+
+        // then: a single bare query returns its rows directly, matching the documented ReportData
+        // schema (a flat array of row objects) that external consumers such as TolaData rely on
+        assertEquals("""[{"name":"Alice"},{"name":"Bob"}]""", storedData)
+    }
+
+    @Test
+    fun `should wrap a multi-query report in an outer array with one entry per item`() {
+        // given
+        val report =
+            Report(
+                id = "Report:1",
+                title = "Report",
+                items =
+                    listOf(
+                        ReportItem.ReportQuery(sql = "SELECT name FROM foo"),
+                        ReportItem.ReportQuery(sql = "SELECT age FROM bar")
+                    )
+            )
+        val reportCalculation = getPendingReportCalculation()
+
+        whenever(
+            reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:1")))
+        ).thenReturn(reportCalculation)
+
+        whenever(reportStorage.fetchReport(eq(DomainReference("Report:1")))).thenReturn(report)
+
+        whenever(queryStorage.executeQuery(any()))
+            .thenReturn(
+                """[{"name":"Alice"}]""".byteInputStream(),
+                """[{"age":5}]""".byteInputStream()
+            )
+
+        whenever(reportCalculationStorage.storeCalculation(any())).thenAnswer { i -> i.arguments[0] }
+
+        var storedData: String? = null
+        whenever(reportCalculationStorage.addReportCalculationData(any(), any())).thenAnswer { i ->
+            storedData = (i.arguments[1] as InputStream).readBytes().decodeToString()
+            i.arguments[0]
+        }
+
+        // when
+        service.run(ReportCalculationRequest(reportCalculationId = reportCalculation.id))
+
+        // then: multiple items stay wrapped so each item's result remains addressable as data[i]
+        assertEquals("""[[{"name":"Alice"}],[{"age":5}]]""", storedData)
     }
 }

--- a/docs/api-specs/reporting-api-v1.yaml
+++ b/docs/api-specs/reporting-api-v1.yaml
@@ -278,13 +278,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportMetadata'
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ReportMetadata'
         404:
           description: report data is not available yet (when either the calculation id is not valid or the calculation is still running).
             Note that if the report calculation was successfully completed but the result is empty (because no data matched the report's query)
-            then this is not returning a 404 error but a 200 with an empty "items" array.
+            then this is not returning a 404 error but a 200 with an empty "data" array.
           content:
             application/json:
               schema:
@@ -332,7 +329,7 @@ paths:
         404:
           description: report data is not available yet (when either the calculation id is not valid or the calculation is still running).
             Note that if the report calculation was successfully completed but the result is empty (because no data matched the report's query)
-            then this is not returning a 404 error but a 200 with an empty "items" array.
+            then this is not returning a 404 error but a 200 with an empty "data" array.
           content:
             application/json:
               schema:
@@ -648,16 +645,21 @@ components:
           nullable: true
         args:
           type: object
-          description: Input arguments will be injected into the sql query
+          description: >-
+            Input arguments injected into the report's SQL query placeholders (for example
+            $startDate and $endDate). The canonical date-range keys are "startDate" and "endDate".
+            For backwards compatibility the legacy keys "from" and "to" are still accepted on the
+            calculation request and are normalized to "startDate"/"endDate" by the backend, so
+            calculations created before the migration may still expose "from"/"to" here.
           properties:
-            from:
+            startDate:
               type: string
-              description: optional start date for the time period of the data included in the report
+              description: optional start date for the time period of the data included in the report (legacy key "from")
               format: date
               nullable: true
-            to:
+            endDate:
               type: string
-              description: optional end date filtering data included in the report. If no date is given here, all data (possibly filtered by the "from" date) is included. The field considered for date filtering are defined in each report's query specifically.
+              description: optional end date filtering data included in the report. If no date is given here, all data (possibly filtered by the "startDate" date) is included. The field considered for date filtering are defined in each report's query specifically (legacy key "to").
               format: date
               nullable: true
         data:
@@ -691,6 +693,11 @@ components:
             id:
               type: string
               example: ReportCalculation:56f22a52-5863-4d24-9da6-239a34ea83ba
+        dataHash:
+          type: string
+          description: Hash of the calculated data, identical to the stored attachment digest.
+            Use it to detect whether a report's result actually changed between two calculations.
+          example: md5-pWo9Wj3ZZ27RqJUoh8C6VA==
         data:
           $ref: '#/components/schemas/ReportData'
 
@@ -716,30 +723,45 @@ components:
 
     ReportData:
       type: array
+      description: |-
+        The calculated report result. Its top-level structure depends on the report definition:
+
+        * Single-query report: `data` is the flat list of result rows, each row a JSON object of
+          column name -> value, e.g.
+          `[ { "name": "Alice", "privateSchool": 1 }, { "name": "Bob", "privateSchool": 0 } ]`.
+
+        * Report with multiple queries and/or groups: `data` holds one entry per top-level report
+          item, in definition order, where
+            - a query item contributes an array of its result rows (`[ { ... }, { ... } ]`), and
+            - a group item contributes a single-key object `{ "<groupTitle>": [ ... ] }` whose value
+              is, recursively, the list of that group's item results.
+
+        A successful calculation that matched no data returns an empty array (`[]`).
       items:
-        type: object
-        description: JSON object containing one row of results
+        oneOf:
+          - type: object
+            description: >-
+              Either a single result row (column name to value) for single-query reports,
+              or a group node keyed by its group title, of the form { "groupTitle": [ ... ] }.
+          - type: array
+            description: The result rows of one query; used when the report has multiple items.
+            items:
+              type: object
       example: |-
         [
+          [
+            { "New students": 6 }
+          ],
           {
-            "foo": 1
-          },
-          {
-            "bar": 2
-          },
-          {
-            "doo": [
-              {
-                "doo foo": 0
-              },
-              {
-                "doo bar": 4
-              }
+            "Students gender": [
+              [ { "male": 6 } ],
+              [ { "female": 4 } ]
             ]
           },
-          {
-            "dua": 0
-          }
+          [
+            { "count": 3, "project": "FOO", "school": "SchoolA" },
+            { "count": 1, "project": "BAR", "school": "SchoolB" }
+          ]
         ]
 
     WebhookConfiguration:

--- a/docs/api-specs/reporting-api-v1.yaml
+++ b/docs/api-specs/reporting-api-v1.yaml
@@ -281,7 +281,7 @@ paths:
         404:
           description: report data is not available yet (when either the calculation id is not valid or the calculation is still running).
             Note that if the report calculation was successfully completed but the result is empty (because no data matched the report's query)
-            then this is not returning a 404 error but a 200 with an empty "data" array.
+            then this is not returning a 404 error but a 200 with an empty array.
           content:
             application/json:
               schema:
@@ -329,7 +329,7 @@ paths:
         404:
           description: report data is not available yet (when either the calculation id is not valid or the calculation is still running).
             Note that if the report calculation was successfully completed but the result is empty (because no data matched the report's query)
-            then this is not returning a 404 error but a 200 with an empty "data" array.
+            then this is not returning a 404 error but a 200 with an empty array.
           content:
             application/json:
               schema:


### PR DESCRIPTION
- closes #145

--> rever back to promised API shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified E2E testing instructions with Docker daemon and JDK 21 prerequisites
  * Updated API documentation for report endpoints, response structures, and schemas
  * Documented date range parameter updates with legacy support

* **Improvements**
  * Optimized report calculation response structure for simplified data handling
  * Added dataHash property to report metadata in API responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->