### PR TITLE
chore: repoint sqs image to ghcr.io/aam-digital/sqs-aam

### DIFF
--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/container/TestContainers.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/container/TestContainers.kt
@@ -120,8 +120,8 @@ object TestContainers {
     val CONTAINER_SQS: GenericContainer<*> =
         GenericContainer(
             DockerImageName
-                .parse("ghcr.io/aam-digital/aam-sqs-linux")
-                .asCompatibleSubstituteFor("aam-sqs-linux")
+                .parse("ghcr.io/aam-digital/sqs-aam")
+                .asCompatibleSubstituteFor("sqs-aam")
                 .withTag("latest")
         ).withNetwork(network)
             .withNetworkAliases("sqs")

--- a/docs/developer/docker-compose.yml
+++ b/docs/developer/docker-compose.yml
@@ -236,7 +236,7 @@ services:
   # ***************************************************************
 
   sqs:
-    image: ghcr.io/aam-digital/aam-sqs-linux:latest
+    image: ghcr.io/aam-digital/sqs-aam:latest
     platform: linux/amd64
     networks:
       - aam-digital

--- a/docs/developer/sql-test-environment/docker-compose.yml
+++ b/docs/developer/sql-test-environment/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "5984:5984"
 
   sqs:
-    image: ghcr.io/aam-digital/aam-sqs-linux:latest
+    image: ghcr.io/aam-digital/sqs-aam:latest
     #    platform: linux/amd64
     depends_on:
       - db-couch


### PR DESCRIPTION
## Summary

The SQS (Structured Query Server) image moved out of `aam-cloud-infrastructure` into the dedicated **[Aam-Digital/sqs-aam](https://github.com/Aam-Digital/sqs-aam)** repo (per https://github.com/Aam-Digital/aam-cloud-infrastructure/issues/146). This repoints all consumers from the old `aam-sqs-linux` package to the new `sqs-aam` image.

Changed (`aam-sqs-linux` → `sqs-aam`, `:latest` kept):
- `docs/developer/docker-compose.yml` — `sqs` service
- `docs/developer/sql-test-environment/docker-compose.yml` — `sqs` service
- `application/aam-backend-service/.../TestContainers.kt` — integration-test `CONTAINER_SQS` (image name + `asCompatibleSubstituteFor`; `.withTag("latest")` unchanged)

Same image content (SQS 1.12.1, linux/amd64), pure rename — no behaviour change. The package stays private (same as before), so existing ghcr pull credentials still apply (incl. CI for the integration tests).

Refs https://github.com/Aam-Digital/aam-cloud-infrastructure/issues/146