### PR TITLE
refactor: merge NetworkException into ExternalSystemException (#44)

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/error/AamException.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/error/AamException.kt
@@ -14,30 +14,8 @@ class InternalServerException(
     code: AamErrorCode
 ) : AamException(message, cause, code)
 
-/**
- * @deprecated
- * TODO merge with network exception and rename to IOException
- * (https://github.com/Aam-Digital/aam-services/issues/44)
- */
 class ExternalSystemException(
     message: String = "Unspecific ExternalSystemException",
-    cause: Throwable? = null,
-    code: AamErrorCode
-) : AamException(message, cause, code)
-
-/**
- * @deprecated
- * TODO merge with network exception and rename to IOException
- * (https://github.com/Aam-Digital/aam-services/issues/44)
- */
-class NetworkException(
-    message: String = "Unspecific NetworkException",
-    cause: Throwable? = null,
-    code: AamErrorCode
-) : AamException(message, cause, code)
-
-class IOException(
-    message: String = "Unspecific IOException",
     cause: Throwable? = null,
     code: AamErrorCode
 ) : AamException(message, cause, code)

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/rest/AamErrorAttributes.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/rest/AamErrorAttributes.kt
@@ -3,10 +3,8 @@ package com.aamdigital.aambackendservice.common.rest
 import com.aamdigital.aambackendservice.common.error.AamException
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
 import com.aamdigital.aambackendservice.common.error.ForbiddenAccessException
-import com.aamdigital.aambackendservice.common.error.IOException
 import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.common.error.UnauthorizedAccessException
 import org.springframework.boot.web.error.ErrorAttributeOptions
@@ -69,9 +67,7 @@ class AamErrorAttributes : DefaultErrorAttributes() {
     private fun getStatus(error: AamException) =
         when (error) {
             is InternalServerException -> HttpStatus.INTERNAL_SERVER_ERROR.value()
-            is IOException -> HttpStatus.INTERNAL_SERVER_ERROR.value()
             is ExternalSystemException -> HttpStatus.INTERNAL_SERVER_ERROR.value()
-            is NetworkException -> HttpStatus.INTERNAL_SERVER_ERROR.value()
             is InvalidArgumentException -> HttpStatus.BAD_REQUEST.value()
             is UnauthorizedAccessException -> HttpStatus.UNAUTHORIZED.value()
             is ForbiddenAccessException -> HttpStatus.FORBIDDEN.value()

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/core/TemplateStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/core/TemplateStorage.kt
@@ -2,14 +2,12 @@ package com.aamdigital.aambackendservice.export.core
 
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 
 interface TemplateStorage {
     @Throws(
         NotFoundException::class,
-        ExternalSystemException::class,
-        NetworkException::class
+        ExternalSystemException::class
     )
     fun fetchTemplate(template: DomainReference): TemplateExport
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/storage/DefaultTemplateStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/storage/DefaultTemplateStorage.kt
@@ -4,7 +4,6 @@ import com.aamdigital.aambackendservice.common.couchdb.core.CouchDbClient
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.error.AamErrorCode
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.export.core.TemplateExport
 import com.aamdigital.aambackendservice.export.core.TemplateStorage
@@ -35,8 +34,7 @@ class DefaultTemplateStorage(
 
     @Throws(
         NotFoundException::class,
-        ExternalSystemException::class,
-        NetworkException::class
+        ExternalSystemException::class
     )
     override fun fetchTemplate(template: DomainReference): TemplateExport {
         val document =
@@ -48,7 +46,7 @@ class DefaultTemplateStorage(
                     kClass = TemplateExportDto::class
                 )
             } catch (ex: InterruptedIOException) {
-                throw NetworkException(
+                throw ExternalSystemException(
                     cause = ex,
                     message = ex.localizedMessage,
                     code = DefaultTemplateStorageErrorCode.IO_NETWORK_ERROR

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/CarboneRenderApiClient.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/CarboneRenderApiClient.kt
@@ -3,7 +3,6 @@ package com.aamdigital.aambackendservice.export.usecase
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.error.AamErrorCode
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.export.core.TemplateExport
 import com.aamdigital.aambackendservice.export.core.TemplateStorage
@@ -67,8 +66,8 @@ internal class CarboneRenderApiClient(
                         code = notFoundCode,
                     )
 
-                is NetworkException ->
-                    NetworkException(
+                is ExternalSystemException ->
+                    ExternalSystemException(
                         cause = ex.cause ?: ex,
                         message = ex.localizedMessage,
                         code = fetchTemplateFailedCode,
@@ -158,7 +157,7 @@ internal class CarboneRenderApiClient(
         } catch (ex: Exception) {
             throw when (ex) {
                 is ResourceAccessException ->
-                    NetworkException(
+                    ExternalSystemException(
                         cause = ex.cause ?: ex,
                         message = ex.localizedMessage,
                         code = fetchRenderResultFailedCode,

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultFetchTemplateUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultFetchTemplateUseCase.kt
@@ -4,7 +4,6 @@ import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
 import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome.Success
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.export.core.FetchTemplateData
 import com.aamdigital.aambackendservice.export.core.FetchTemplateError
@@ -68,7 +67,7 @@ class DefaultFetchTemplateUseCase(
                             )
                     }
             } catch (ex: ResourceAccessException) {
-                throw NetworkException(
+                throw ExternalSystemException(
                     cause = ex,
                     message = ex.localizedMessage,
                     code = FetchTemplateError.FETCH_TEMPLATE_REQUEST_FAILED_ERROR

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/controller/ReportController.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/controller/ReportController.kt
@@ -4,7 +4,6 @@ import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.error.AamException
 import com.aamdigital.aambackendservice.common.error.HttpErrorDto
 import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
 import com.aamdigital.aambackendservice.reporting.report.ReportSchema
@@ -81,16 +80,6 @@ class ReportController(
                     .body(
                         HttpErrorDto(
                             errorCode = "NOT_FOUND",
-                            errorMessage = ex.localizedMessage
-                        )
-                    )
-
-            is NetworkException ->
-                ResponseEntity
-                    .status(HttpStatus.BAD_GATEWAY)
-                    .body(
-                        HttpErrorDto(
-                            errorCode = "GATEWAY_TIMEOUT",
                             errorMessage = ex.localizedMessage
                         )
                     )

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorage.kt
@@ -4,9 +4,9 @@ import com.aamdigital.aambackendservice.common.couchdb.core.CouchDbClient
 import com.aamdigital.aambackendservice.common.couchdb.core.getQueryParamsAllDocs
 import com.aamdigital.aambackendservice.common.couchdb.dto.CouchDbSearchResponse
 import com.aamdigital.aambackendservice.common.domain.DomainReference
+import com.aamdigital.aambackendservice.common.error.ExternalSystemException
 import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.reporting.report.Report
 import com.aamdigital.aambackendservice.reporting.report.ReportItem
@@ -57,7 +57,7 @@ class DefaultReportStorage(
 
     @Throws(
         InvalidArgumentException::class,
-        NetworkException::class,
+        ExternalSystemException::class,
         InternalServerException::class,
         NotFoundException::class
     )
@@ -147,7 +147,7 @@ class DefaultReportStorage(
                 )
 
             is InterruptedIOException ->
-                NetworkException(
+                ExternalSystemException(
                     message = ex.localizedMessage,
                     cause = ex,
                     code = DefaultReportCalculationStorageError.NETWORK_ERROR

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/storage/DefaultReportCalculationStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/storage/DefaultReportCalculationStorage.kt
@@ -8,7 +8,6 @@ import com.aamdigital.aambackendservice.common.domain.FileStorage
 import com.aamdigital.aambackendservice.common.error.AamErrorCode
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
 import com.aamdigital.aambackendservice.common.error.InternalServerException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculation
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationStorage
@@ -88,8 +87,7 @@ class DefaultReportCalculationStorage(
 
     @Throws(
         NotFoundException::class,
-        ExternalSystemException::class,
-        NetworkException::class
+        ExternalSystemException::class
     )
     override fun fetchReportCalculation(calculation: DomainReference): ReportCalculation =
         try {
@@ -158,14 +156,14 @@ class DefaultReportCalculationStorage(
                 )
 
             is InterruptedIOException ->
-                NetworkException(
+                ExternalSystemException(
                     message = ex.localizedMessage,
                     cause = ex,
                     code = DefaultReportCalculationStorageError.NETWORK_ERROR
                 )
 
             is HttpClientErrorException ->
-                NetworkException(
+                ExternalSystemException(
                     message = ex.localizedMessage,
                     cause = ex,
                     code = DefaultReportCalculationStorageError.NETWORK_ERROR

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
@@ -6,7 +6,6 @@ import com.aamdigital.aambackendservice.common.error.AamException
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
 import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.error.InvalidArgumentException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.reporting.report.Report
 import com.aamdigital.aambackendservice.reporting.report.ReportItem
@@ -275,13 +274,6 @@ class DefaultReportCalculationUseCase(
     ): UseCaseOutcome<ReportCalculationData> {
         val useCaseException: AamException =
             when (exception) {
-                is NetworkException ->
-                    NetworkException(
-                        message = exception.localizedMessage,
-                        code = useCaseStepCode ?: ReportCalculationError.IO_ERROR,
-                        cause = exception
-                    )
-
                 is NotFoundException ->
                     NotFoundException(
                         message = exception.localizedMessage,

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.domain.TestErrorCode
 import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
 import com.aamdigital.aambackendservice.common.error.ExternalSystemException
-import com.aamdigital.aambackendservice.common.error.NetworkException
 import com.aamdigital.aambackendservice.common.error.NotFoundException
 import com.aamdigital.aambackendservice.export.core.RenderTemplateError
 import com.aamdigital.aambackendservice.export.core.RenderTemplateRequest
@@ -432,7 +431,7 @@ class DefaultRenderTemplateUseCaseTest : WebClientTestBase() {
         assertThat(response).isInstanceOf(UseCaseOutcome.Failure::class.java)
 
         assertThat((response as UseCaseOutcome.Failure).cause)
-            .isInstanceOf(NetworkException::class.java)
+            .isInstanceOf(ExternalSystemException::class.java)
 
         assertThat(response.cause?.cause)
             .isInstanceOf(SocketTimeoutException::class.java)


### PR DESCRIPTION
Closes #44.

`NetworkException` and `ExternalSystemException` overlapped with no clear rule for which to use. This merges them into a single type and removes the redundancy.

After discussion we kept **`ExternalSystemException`** as the surviving name rather than `IOException` (which the issue originally suggested), because every throw site is an external-system/dependency failure (CouchDB, Keycloak, SQS, SkillLab, Carbone) and it avoids a name clash with `java.io.IOException`. The unused `IOException` domain class is removed too.

## Changes
- Removed `NetworkException` and the unused `IOException` classes from `AamException.kt`; dropped the deprecation note on `ExternalSystemException`.
- Migrated `NetworkException` references to `ExternalSystemException` (throws, `@Throws` (deduplicated), `::class` / `isInstanceOf`).
- Collapsed the redundant `when` branches in `AamErrorAttributes`, `DefaultReportCalculationUseCase`, and `CarboneRenderApiClient`.

## Behavior
- All three types already mapped to **HTTP 500** in `AamErrorAttributes`, so the global error contract is unchanged.
- `ReportController` previously mapped `NetworkException` to **502 BAD_GATEWAY**; IO failures now return a plain **500**, consistent with the global mapping.
- The merged branch in `DefaultReportCalculationUseCase` keeps `ExternalSystemException`'s existing `UNEXPECTED_ERROR` default code (the former `NetworkException` branch defaulted to `IO_ERROR`). Internal `errorCode` only; no test asserts it.

## Verification
- `compileKotlin` + `compileTestKotlin` pass.
- Affected unit-test classes pass (report calculation, render/fetch template, SQS query, report storage, SkillLab client, CouchDb changes processor).
- Full Cucumber/integration suite not run locally (requires Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
