### PR TITLE
fix: disable HTTP keep-alive towards SQS to prevent connection resets

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/SqsConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/SqsConfiguration.kt
@@ -3,6 +3,7 @@ package com.aamdigital.aambackendservice.reporting.report.di
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
 import org.springframework.web.client.RestClient
 
 @Configuration
@@ -18,6 +19,12 @@ class SqsConfiguration {
                         configuration.basicAuthUsername,
                         configuration.basicAuthPassword
                     )
+                    // SQS's Node server intermittently resets reused keep-alive connections when a
+                    // long, event-loop-blocking query follows a quickly answered one, discarding the
+                    // response after computing it (backend then sees "Connection reset"). Closing the
+                    // connection after every exchange avoids reuse on both sides; with multi-second
+                    // query times the extra TCP handshake per request is negligible.
+                    it.set(HttpHeaders.CONNECTION, "close")
                 }
 
         return clientBuilder.build()

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/di/SqsConfigurationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/di/SqsConfigurationTest.kt
@@ -1,0 +1,54 @@
+package com.aamdigital.aambackendservice.reporting.report.di
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class SqsConfigurationTest {
+    private lateinit var mockWebServer: MockWebServer
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `should not reuse connections so that SQS cannot reset a pooled connection mid-query`() {
+        // Given
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
+        val client =
+            SqsConfiguration().sqsRestClient(
+                SqsClientConfiguration(
+                    basePath = mockWebServer.url("/").toString(),
+                    basicAuthUsername = "admin",
+                    basicAuthPassword = "secret",
+                )
+            )
+
+        // When
+        repeat(2) {
+            client.post().uri("/app/_design/sqlite:config").body("{}").retrieve().body(String::class.java)
+        }
+
+        // Then
+        val firstRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!
+        val secondRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!
+        assertThat(firstRequest.getHeader("Connection")).isEqualToIgnoringCase("close")
+        assertThat(secondRequest.getHeader("Connection")).isEqualToIgnoringCase("close")
+        assertThat(firstRequest.getHeader("Authorization")).startsWith("Basic ")
+        // sequenceNumber restarts at 0 for each TCP connection: both being 0 proves no keep-alive reuse
+        assertThat(firstRequest.sequenceNumber).isEqualTo(0)
+        assertThat(secondRequest.sequenceNumber).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## Problem

`SocketException: Connection reset` in `SqsQueryStorage.executeQuery` ([AAM-BACKEND-SERVICE-80](https://aam-digital.sentry.io/issues/7587073507), 44 events, all from a single large production instance) causing report calculations to fail intermittently.

## Diagnosis

Cross-referencing Sentry breadcrumbs with the SQS container logs showed:

- SQS **successfully executed every query and logged `200 OK`** — including the exact requests the backend recorded as connection reset (~6.5s response times).
- The RST reached the backend a fraction of a second *before* SQS logged response-complete: the Node server destroys the socket right as the handler finishes and writes the response into a dead socket.
- Failing requests were always the **second request on a reused keep-alive connection** whose first request was answered fast (~130–160 ms, apparently cached); a reused connection with a slow first request succeeded. Node's default `keepAliveTimeout` is 5s and the synchronous SQLite query blocks its event loop for ~6.5s, so this looks like a socket-teardown race on the SQS side.
- OOM/crash ruled out: `oom_kill 0`, `OOMKilled=false`, `RestartCount=0`, same pid throughout.

## Fix

Send `Connection: close` on the SQS `RestClient`, so both client and server use a fresh connection per request — eliminating the reuse race regardless of the exact Node-internal cause. Queries take multiple seconds, so one extra TCP handshake per request on the Docker network is negligible.

The new test asserts real behavior via MockWebServer (`sequenceNumber == 0` for consecutive requests proves no connection reuse) and fails without the fix.

Follow-ups (separate): report the server-side behavior upstream to the SQS maintainers, and dedupe duplicate `ReportCalculation`s queued for the same report within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of SQS-related requests by closing connections after each exchange, reducing intermittent connection reset issues.
  * Added coverage to ensure requests include the expected connection and authorization headers, and that connections are not reused unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->