### PR TITLE
feat: debounce automatic report calculations triggered by document changes

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/scheduling/SchedulingConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/scheduling/SchedulingConfiguration.kt
@@ -1,0 +1,31 @@
+package com.aamdigital.aambackendservice.common.scheduling
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+/**
+ * Provides an explicit pooled [TaskScheduler] for all `@Scheduled` jobs.
+ *
+ * With `spring.threads.virtual.enabled=true`, Spring Boot would otherwise auto-configure a
+ * `SimpleAsyncTaskScheduler` that runs every `fixedDelay` task on a single shared scheduler
+ * thread. All scheduled jobs here use `fixedDelay`, so they would serialize on that one thread:
+ * a slow flush in [com.aamdigital.aambackendservice.reporting.reportcalculation.job.ReportCalculationDebounceJob]
+ * (which does CouchDB I/O per due report) could then delay the frequent
+ * [com.aamdigital.aambackendservice.common.changes.CouchDbChangesPollingJob] and stall change detection.
+ *
+ * Defining this bean makes it the [TaskScheduler] used for `@Scheduled` (the auto-configuration
+ * backs off on the existing bean), giving the jobs their own pool so they no longer block each
+ * other. The pool is sized to the number of scheduled jobs. This only affects scheduling; web
+ * request handling and `@Async` keep using virtual threads.
+ */
+@Configuration
+class SchedulingConfiguration {
+    @Bean
+    fun taskScheduler(): TaskScheduler =
+        ThreadPoolTaskScheduler().apply {
+            poolSize = 3
+            setThreadNamePrefix("scheduled-")
+        }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/ReportQueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/ReportQueueConfiguration.kt
@@ -4,8 +4,8 @@ import com.aamdigital.aambackendservice.common.queue.core.QueueMessageParser
 import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
 import com.aamdigital.aambackendservice.reporting.report.core.IdentifyAffectedReportsUseCase
 import com.aamdigital.aambackendservice.reporting.report.queue.ReportDocumentChangeEventConsumer
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationDebouncer
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
@@ -38,14 +38,14 @@ class ReportQueueConfiguration {
     @Bean("report-document-changes-consumer")
     fun reportDocumentChangeEventConsumer(
         messageParser: QueueMessageParser,
-        createReportCalculationUseCase: CreateReportCalculationUseCase,
+        reportCalculationDebouncer: ReportCalculationDebouncer,
         reportCalculationChangeUseCase: ReportCalculationChangeUseCase,
         identifyAffectedReportsUseCase: IdentifyAffectedReportsUseCase,
         webhookStorage: WebhookStorage
     ): ReportDocumentChangeEventConsumer =
         ReportDocumentChangeEventConsumer(
             messageParser,
-            createReportCalculationUseCase,
+            reportCalculationDebouncer,
             reportCalculationChangeUseCase,
             identifyAffectedReportsUseCase,
             webhookStorage

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/queue/ReportDocumentChangeEventConsumer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/queue/ReportDocumentChangeEventConsumer.kt
@@ -7,8 +7,8 @@ import com.aamdigital.aambackendservice.common.queue.core.QueueMessageParser
 import com.aamdigital.aambackendservice.reporting.report.core.IdentifyAffectedReportsUseCase
 import com.aamdigital.aambackendservice.reporting.report.di.ReportQueueConfiguration
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationRequest
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationDebouncer
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import com.rabbitmq.client.Channel
 import org.slf4j.LoggerFactory
@@ -18,7 +18,7 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener
 
 class ReportDocumentChangeEventConsumer(
     private val messageParser: QueueMessageParser,
-    private val createReportCalculationUseCase: CreateReportCalculationUseCase,
+    private val reportCalculationDebouncer: ReportCalculationDebouncer,
     private val reportCalculationChangeUseCase: ReportCalculationChangeUseCase,
     private val identifyAffectedReportsUseCase: IdentifyAffectedReportsUseCase,
     private val webhookStorage: WebhookStorage
@@ -74,15 +74,16 @@ class ReportDocumentChangeEventConsumer(
                             webhook.reportSubscriptions.contains(DomainReference(report.id))
                         }
                     }.forEach { report ->
-                        createReportCalculationUseCase
-                            .createReportCalculation(
-                                request =
-                                    CreateReportCalculationRequest(
-                                        report = report,
-                                        args = mutableMapOf(),
-                                        fromAutomaticChangeDetection = true
-                                    )
-                            )
+                        // debounced: the calculation is only created once changes settle down,
+                        // so bursts of document changes result in a single recalculation
+                        reportCalculationDebouncer.recordChange(
+                            request =
+                                CreateReportCalculationRequest(
+                                    report = report,
+                                    args = mutableMapOf(),
+                                    fromAutomaticChangeDetection = true
+                                )
+                        )
                     }
 
                 return

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncer.kt
@@ -75,25 +75,36 @@ class ReportCalculationDebouncer(
         // debounce window instead of being swallowed by the calculation we create now
         pendingTriggers.remove(reportId)
 
-        when (val result = createReportCalculationUseCase.createReportCalculation(trigger.request)) {
-            is CreateReportCalculationResult.Success -> {
-                logger.debug(
-                    "created debounced report calculation {} for report {}",
-                    result.calculation.id,
-                    reportId,
-                )
-            }
+        try {
+            when (val result = createReportCalculationUseCase.createReportCalculation(trigger.request)) {
+                is CreateReportCalculationResult.Success -> {
+                    logger.debug(
+                        "created debounced report calculation {} for report {}",
+                        result.calculation.id,
+                        reportId,
+                    )
+                }
 
-            is CreateReportCalculationResult.Failure -> {
-                logger.warn(
-                    "could not create debounced report calculation for report {} ({}), will retry: {}",
-                    reportId,
-                    result.errorCode,
-                    result.errorMessage,
-                    result.cause,
-                )
-                restorePendingTrigger(reportId, trigger)
+                is CreateReportCalculationResult.Failure -> {
+                    logger.warn(
+                        "could not create debounced report calculation for report {} ({}), will retry: {}",
+                        reportId,
+                        result.errorCode,
+                        result.errorMessage,
+                        result.cause,
+                    )
+                    restorePendingTrigger(reportId, trigger)
+                }
             }
+        } catch (ex: Exception) {
+            // an unexpected throw (not a Failure result) must not lose the claimed trigger, nor
+            // abort the flush loop over the remaining reports: restore for retry on the next flush
+            logger.error(
+                "unexpected error creating debounced report calculation for report {}, will retry",
+                reportId,
+                ex,
+            )
+            restorePendingTrigger(reportId, trigger)
         }
     }
 

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncer.kt
@@ -1,0 +1,110 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.core
+
+import jakarta.annotation.PreDestroy
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Coalesces bursts of document changes into a single report calculation per report
+ * ("rolling debounce").
+ *
+ * Without debouncing, every changed document triggers its own calculation for each affected
+ * report. During normal editing or bulk imports this queues many redundant back-to-back
+ * calculations that each block SQS for several seconds, even though only the final state of
+ * the database matters (a calculation reads the database at execution time, so the last one
+ * always reflects all previous changes).
+ *
+ * [recordChange] only remembers that a report needs recalculation; the calculation is created
+ * once no further change has arrived for [quietPeriod]. While changes keep arriving, the wait
+ * keeps extending, capped by [maxWait] since the first pending change so that consumers still
+ * get regular intermediate results during long-running imports.
+ *
+ * [flushDueTriggers] must be invoked periodically by a scheduled job. Pending triggers are
+ * held in memory only; on shutdown they are flushed immediately (best-effort).
+ */
+class ReportCalculationDebouncer(
+    private val createReportCalculationUseCase: CreateReportCalculationUseCase,
+    private val quietPeriod: Duration,
+    private val maxWait: Duration,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private class PendingTrigger(
+        val request: CreateReportCalculationRequest,
+        val firstChangeAt: Instant,
+        @Volatile var lastChangeAt: Instant,
+    )
+
+    private val pendingTriggers = ConcurrentHashMap<String, PendingTrigger>()
+
+    fun recordChange(request: CreateReportCalculationRequest) {
+        val now = clock.instant()
+        pendingTriggers.compute(request.report.id) { _, existing ->
+            existing?.also { it.lastChangeAt = now }
+                ?: PendingTrigger(request, firstChangeAt = now, lastChangeAt = now)
+        }
+    }
+
+    fun flushDueTriggers() {
+        val now = clock.instant()
+        pendingTriggers.forEach { (reportId, trigger) ->
+            val quietPeriodElapsed = !now.isBefore(trigger.lastChangeAt.plus(quietPeriod))
+            val maxWaitExceeded = !now.isBefore(trigger.firstChangeAt.plus(maxWait))
+            if (quietPeriodElapsed || maxWaitExceeded) {
+                triggerCalculation(reportId, trigger)
+            }
+        }
+    }
+
+    @PreDestroy
+    fun flushAll() {
+        pendingTriggers.forEach { (reportId, trigger) ->
+            triggerCalculation(reportId, trigger)
+        }
+    }
+
+    private fun triggerCalculation(
+        reportId: String,
+        trigger: PendingTrigger
+    ) {
+        // claim the trigger before creating, so a change arriving concurrently starts a fresh
+        // debounce window instead of being swallowed by the calculation we create now
+        pendingTriggers.remove(reportId)
+
+        when (val result = createReportCalculationUseCase.createReportCalculation(trigger.request)) {
+            is CreateReportCalculationResult.Success -> {
+                logger.debug(
+                    "created debounced report calculation {} for report {}",
+                    result.calculation.id,
+                    reportId,
+                )
+            }
+
+            is CreateReportCalculationResult.Failure -> {
+                logger.warn(
+                    "could not create debounced report calculation for report {} ({}), will retry: {}",
+                    reportId,
+                    result.errorCode,
+                    result.errorMessage,
+                    result.cause,
+                )
+                restorePendingTrigger(reportId, trigger)
+            }
+        }
+    }
+
+    /** Re-registers a failed trigger, merging with any change recorded in the meantime. */
+    private fun restorePendingTrigger(
+        reportId: String,
+        trigger: PendingTrigger
+    ) {
+        pendingTriggers.compute(reportId) { _, newer ->
+            newer?.also { trigger.lastChangeAt = maxOf(trigger.lastChangeAt, it.lastChangeAt) }
+            trigger
+        }
+    }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationConfiguration.kt
@@ -6,7 +6,9 @@ import com.aamdigital.aambackendservice.common.domain.FileStorage
 import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
 import com.aamdigital.aambackendservice.reporting.report.core.QueryStorage
 import com.aamdigital.aambackendservice.reporting.report.core.ReportStorage
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationDebouncer
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationStorage
 import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.RabbitMqReportCalculationEventPublisher
 import com.aamdigital.aambackendservice.reporting.reportcalculation.storage.DefaultReportCalculationStorage
@@ -20,8 +22,10 @@ import com.aamdigital.aambackendservice.reporting.webhook.core.NotificationServi
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.Duration
 
 @Configuration
 @ConditionalOnReportingEnabled
@@ -51,6 +55,18 @@ class ReportCalculationConfiguration {
         reportCalculationStorage: ReportCalculationStorage,
         reportCalculationEventPublisher: RabbitMqReportCalculationEventPublisher
     ) = DefaultCreateReportCalculationUseCase(reportCalculationStorage, reportCalculationEventPublisher)
+
+    @Bean
+    fun reportCalculationDebouncer(
+        createReportCalculationUseCase: CreateReportCalculationUseCase,
+        @Value("\${report-calculation-debounce.quiet-period-seconds:60}") quietPeriodSeconds: Long,
+        @Value("\${report-calculation-debounce.max-wait-seconds:300}") maxWaitSeconds: Long,
+    ): ReportCalculationDebouncer =
+        ReportCalculationDebouncer(
+            createReportCalculationUseCase = createReportCalculationUseCase,
+            quietPeriod = Duration.ofSeconds(quietPeriodSeconds),
+            maxWait = Duration.ofSeconds(maxWaitSeconds),
+        )
 
     @Bean
     fun getSqlFromDateTransformation(): DataTransformation<String> = SqlFromDateTransformation()

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/job/ReportCalculationDebounceJob.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/job/ReportCalculationDebounceJob.kt
@@ -1,0 +1,22 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.job
+
+import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationDebouncer
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.Scheduled
+
+/**
+ * Periodically flushes debounced report calculation triggers
+ * (see [ReportCalculationDebouncer]). Failed creations stay registered in the
+ * debouncer and are retried on the next flush, so no backoff handling is needed here.
+ */
+@Configuration
+@ConditionalOnReportingEnabled
+class ReportCalculationDebounceJob(
+    private val reportCalculationDebouncer: ReportCalculationDebouncer,
+) {
+    @Scheduled(fixedDelayString = "\${report-calculation-debounce.flush-fixed-delay:10000}")
+    fun flushDueReportCalculations() {
+        reportCalculationDebouncer.flushDueTriggers()
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/core/ReportDocumentChangeEventConsumerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/core/ReportDocumentChangeEventConsumerTest.kt
@@ -1,22 +1,37 @@
 package com.aamdigital.aambackendservice.reporting.report.core
 
+import com.aamdigital.aambackendservice.common.changes.DocumentChangeEvent
+import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.domain.TestErrorCode
 import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.queue.core.QueueMessageParser
 import com.aamdigital.aambackendservice.reporting.report.queue.ReportDocumentChangeEventConsumer
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationRequest
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationDebouncer
+import com.aamdigital.aambackendservice.reporting.webhook.Webhook
+import com.aamdigital.aambackendservice.reporting.webhook.WebhookAuthentication
+import com.aamdigital.aambackendservice.reporting.webhook.WebhookAuthenticationType
+import com.aamdigital.aambackendservice.reporting.webhook.WebhookTarget
+import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookOwner
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import com.rabbitmq.client.Channel
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.amqp.AmqpRejectAndDontRequeueException
 import org.springframework.amqp.core.Message
@@ -35,7 +50,7 @@ class ReportDocumentChangeEventConsumerTest {
     lateinit var mockChannel: Channel
 
     @Mock
-    lateinit var createReportCalculationUseCase: CreateReportCalculationUseCase
+    lateinit var reportCalculationDebouncer: ReportCalculationDebouncer
 
     @Mock
     lateinit var reportCalculationChangeUseCase: ReportCalculationChangeUseCase
@@ -46,11 +61,14 @@ class ReportDocumentChangeEventConsumerTest {
     @Mock
     lateinit var webhookStorage: WebhookStorage
 
+    @Captor
+    lateinit var requestCaptor: ArgumentCaptor<CreateReportCalculationRequest>
+
     @BeforeEach
     fun setUp() {
         reset(
             messageParser,
-            createReportCalculationUseCase,
+            reportCalculationDebouncer,
             reportCalculationChangeUseCase,
             identifyAffectedReportsUseCase,
             webhookStorage
@@ -59,7 +77,7 @@ class ReportDocumentChangeEventConsumerTest {
         service =
             ReportDocumentChangeEventConsumer(
                 messageParser = messageParser,
-                createReportCalculationUseCase = createReportCalculationUseCase,
+                reportCalculationDebouncer = reportCalculationDebouncer,
                 reportCalculationChangeUseCase = reportCalculationChangeUseCase,
                 identifyAffectedReportsUseCase = identifyAffectedReportsUseCase,
                 webhookStorage = webhookStorage
@@ -108,5 +126,55 @@ class ReportDocumentChangeEventConsumerTest {
 
         // then
         Assertions.assertTrue(response.localizedMessage.startsWith("[NO_USECASE_CONFIGURED]"))
+    }
+
+    @Test
+    fun `should record debounced calculation trigger only for webhook-subscribed affected reports`() {
+        // given
+        val rawMessage = "foo"
+        val documentChangeEvent =
+            DocumentChangeEvent(
+                database = "app",
+                documentId = "individualSurvey:1",
+                rev = "1-abc",
+                currentVersion = mapOf<String, String>(),
+                previousVersion = mapOf<String, String>(),
+                deleted = false
+            )
+
+        whenever(messageParser.getTypeKClass(any())).thenAnswer { DocumentChangeEvent::class }
+        whenever(messageParser.getPayload(any(), eq(DocumentChangeEvent::class))).thenReturn(documentChangeEvent)
+        whenever(identifyAffectedReportsUseCase.analyse(documentChangeEvent))
+            .thenReturn(
+                listOf(
+                    DomainReference("ReportConfig:subscribed-report"),
+                    DomainReference("ReportConfig:unsubscribed-report"),
+                )
+            )
+        whenever(webhookStorage.fetchAllWebhooks())
+            .thenReturn(
+                listOf(
+                    Webhook(
+                        id = "Webhook:1",
+                        label = "test webhook",
+                        target = WebhookTarget(method = "POST", url = "https://example.org"),
+                        authentication =
+                            WebhookAuthentication(
+                                type = WebhookAuthenticationType.API_KEY,
+                                secret = "secret"
+                            ),
+                        owner = WebhookOwner(creator = "user"),
+                        reportSubscriptions = mutableListOf(DomainReference("ReportConfig:subscribed-report"))
+                    )
+                )
+            )
+
+        // when
+        service.consume(rawMessage, mockMessage, mockChannel)
+
+        // then
+        verify(reportCalculationDebouncer, times(1)).recordChange(capture(requestCaptor))
+        assertThat(requestCaptor.value.report.id).isEqualTo("ReportConfig:subscribed-report")
+        assertThat(requestCaptor.value.fromAutomaticChangeDetection).isTrue()
     }
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationDebouncerTest.kt
@@ -1,0 +1,197 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.core
+
+import com.aamdigital.aambackendservice.common.domain.DomainReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReportCalculationDebouncerTest {
+    private class MutableClock(
+        private var current: Instant
+    ) : Clock() {
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId): Clock = this
+
+        override fun instant(): Instant = current
+
+        fun advanceBy(duration: Duration) {
+            current += duration
+        }
+    }
+
+    private lateinit var service: ReportCalculationDebouncer
+    private lateinit var clock: MutableClock
+
+    @Mock
+    lateinit var createReportCalculationUseCase: CreateReportCalculationUseCase
+
+    @Captor
+    lateinit var requestCaptor: ArgumentCaptor<CreateReportCalculationRequest>
+
+    private val quietPeriod: Duration = Duration.ofSeconds(60)
+    private val maxWait: Duration = Duration.ofSeconds(300)
+
+    @BeforeEach
+    fun setUp() {
+        reset(createReportCalculationUseCase)
+        whenever(createReportCalculationUseCase.createReportCalculation(any()))
+            .thenReturn(CreateReportCalculationResult.Success(DomainReference("ReportCalculation:1")))
+
+        clock = MutableClock(Instant.parse("2026-01-01T00:00:00Z"))
+        service =
+            ReportCalculationDebouncer(
+                createReportCalculationUseCase = createReportCalculationUseCase,
+                quietPeriod = quietPeriod,
+                maxWait = maxWait,
+                clock = clock,
+            )
+    }
+
+    private fun requestFor(reportId: String): CreateReportCalculationRequest =
+        CreateReportCalculationRequest(
+            report = DomainReference(reportId),
+            args = mutableMapOf(),
+            fromAutomaticChangeDetection = true
+        )
+
+    @Test
+    fun `should coalesce a burst of changes into a single calculation after the quiet period`() {
+        // given
+        repeat(5) {
+            service.recordChange(requestFor("ReportConfig:report-a"))
+            clock.advanceBy(Duration.ofMillis(100))
+        }
+
+        // when
+        clock.advanceBy(quietPeriod)
+        service.flushDueTriggers()
+
+        // then
+        verify(createReportCalculationUseCase, times(1)).createReportCalculation(capture(requestCaptor))
+        assertThat(requestCaptor.value.report.id).isEqualTo("ReportConfig:report-a")
+        assertThat(requestCaptor.value.fromAutomaticChangeDetection).isTrue()
+    }
+
+    @Test
+    fun `should not create a calculation before the quiet period has elapsed`() {
+        // given
+        service.recordChange(requestFor("ReportConfig:report-a"))
+
+        // when
+        clock.advanceBy(quietPeriod.minusSeconds(1))
+        service.flushDueTriggers()
+
+        // then
+        verify(createReportCalculationUseCase, never()).createReportCalculation(any())
+    }
+
+    @Test
+    fun `should extend the wait while new changes keep arriving (rolling debounce)`() {
+        // given
+        service.recordChange(requestFor("ReportConfig:report-a"))
+        clock.advanceBy(Duration.ofSeconds(45))
+        service.flushDueTriggers()
+        service.recordChange(requestFor("ReportConfig:report-a"))
+
+        // when: quiet period since the FIRST change has elapsed, but not since the latest one
+        clock.advanceBy(Duration.ofSeconds(45))
+        service.flushDueTriggers()
+
+        // then
+        verify(createReportCalculationUseCase, never()).createReportCalculation(any())
+
+        // when: quiet period since the latest change has elapsed
+        clock.advanceBy(Duration.ofSeconds(20))
+        service.flushDueTriggers()
+
+        // then
+        verify(createReportCalculationUseCase, times(1)).createReportCalculation(any())
+    }
+
+    @Test
+    fun `should create a calculation after max wait even when changes arrive continuously`() {
+        // given: a change every 30s keeps the quiet period from ever elapsing
+        service.recordChange(requestFor("ReportConfig:report-a"))
+
+        // when
+        repeat(10) {
+            clock.advanceBy(Duration.ofSeconds(30))
+            service.recordChange(requestFor("ReportConfig:report-a"))
+            service.flushDueTriggers()
+        }
+
+        // then: created exactly once, when maxWait since the first change was reached
+        verify(createReportCalculationUseCase, times(1)).createReportCalculation(any())
+    }
+
+    @Test
+    fun `should debounce reports independently`() {
+        // given
+        service.recordChange(requestFor("ReportConfig:report-a"))
+        clock.advanceBy(quietPeriod)
+        service.recordChange(requestFor("ReportConfig:report-b"))
+
+        // when
+        service.flushDueTriggers()
+
+        // then: only report-a is due; report-b was changed just now
+        verify(createReportCalculationUseCase, times(1)).createReportCalculation(capture(requestCaptor))
+        assertThat(requestCaptor.value.report.id).isEqualTo("ReportConfig:report-a")
+    }
+
+    @Test
+    fun `should retry on the next flush when creating the calculation fails`() {
+        // given
+        whenever(createReportCalculationUseCase.createReportCalculation(any()))
+            .thenReturn(
+                CreateReportCalculationResult.Failure(
+                    errorCode = CreateReportCalculationResult.ErrorCode.INTERNAL_SERVER_ERROR
+                )
+            ).thenReturn(CreateReportCalculationResult.Success(DomainReference("ReportCalculation:1")))
+        service.recordChange(requestFor("ReportConfig:report-a"))
+        clock.advanceBy(quietPeriod)
+
+        // when
+        service.flushDueTriggers()
+        service.flushDueTriggers()
+        service.flushDueTriggers()
+
+        // then: first attempt failed and was retried once; after success nothing is pending anymore
+        verify(createReportCalculationUseCase, times(2)).createReportCalculation(any())
+    }
+
+    @Test
+    fun `should create pending calculations immediately on flushAll (shutdown)`() {
+        // given: changes recorded just now, quiet period NOT elapsed
+        service.recordChange(requestFor("ReportConfig:report-a"))
+        service.recordChange(requestFor("ReportConfig:report-b"))
+
+        // when
+        service.flushAll()
+
+        // then
+        verify(createReportCalculationUseCase, times(2)).createReportCalculation(any())
+    }
+}

--- a/docs/modules/reporting.md
+++ b/docs/modules/reporting.md
@@ -121,3 +121,23 @@ _... when data in Aam Digital changes (and once initially directly after you sub
 6. Use the report-calculation-id in the event to fetch actual data:
    - get metadata like timestamp of the calculation: `GET /v1/reporting/report-calculation/<calculation-id>`
    - get the actual report data: `GET /v1/reporting/report-calculation/<calculation-id>/data`
+
+### Debouncing of automatic report calculations
+
+When data in Aam Digital changes, affected subscribed reports are not recalculated once per
+changed document. Instead, changes are debounced: the calculation runs once no further change
+has arrived for a quiet period, so a burst of edits (or a bulk import) results in a single
+recalculation reflecting the final state. While changes keep arriving continuously, an
+intermediate calculation is still triggered regularly (max wait), so subscribers receive
+updates during long-running imports.
+
+This behaviour can be tuned via environment variables / application properties (defaults shown):
+
+| Property                                            | Default | Description                                                              |
+|-----------------------------------------------------|---------|--------------------------------------------------------------------------|
+| `report-calculation-debounce.quiet-period-seconds`  | `60`    | wait this long after the last change before calculating                   |
+| `report-calculation-debounce.max-wait-seconds`      | `300`   | calculate at least this often while changes keep arriving                 |
+| `report-calculation-debounce.flush-fixed-delay`     | `10000` | interval (ms) at which pending triggers are checked                       |
+
+Manually triggered calculations (`POST /v1/reporting/report-calculation/report/<report-id>`)
+are not debounced and always run immediately.


### PR DESCRIPTION
## Problem

Every changed document immediately creates its own report calculation for each webhook-subscribed report. Analysis of production logs showed:

- **643 calculations in a single day — 173 for one report alone** (~20 min of blocking SQS compute), triggered by 393 document changes during normal data entry.
- Two records saved within the same seconds produce duplicate back-to-back calculations of the same report — the pattern that triggered the SQS connection resets ([AAM-BACKEND-SERVICE-80](https://aam-digital.sentry.io/issues/7587073507), see #153).
- The existing PENDING dedup in `DefaultCreateReportCalculationUseCase` rarely takes effect: idle queue consumers pick up a PENDING calculation within ~100 ms, moving it to RUNNING before the next document change is analysed — and RUNNING must not simply be deduped, since a running query may have read data from before the newest change.

## Solution: rolling debounce

`ReportDocumentChangeEventConsumer` no longer creates calculations directly. It records a trigger in the new `ReportCalculationDebouncer`, and a scheduled job flushes triggers that are *due*:

- **Quiet period (default 60s, rolling)**: the calculation is created once no further change has arrived for this long — a burst of edits or a bulk import collapses into a single recalculation reflecting the final DB state (a calculation reads the database at execution time, so the last one covers all coalesced changes).
- **Max wait (default 5 min)**: while changes keep arriving continuously, a calculation is still created at least this often, so webhook subscribers receive intermediate results during long-running imports.
- Failed creations stay registered and are retried on the next flush; on shutdown, pending triggers are flushed immediately (best-effort).
- Manually triggered calculations via the API (`fromAutomaticChangeDetection = false` path) are unaffected and still run immediately.

Timings are configurable (`report-calculation-debounce.quiet-period-seconds`, `.max-wait-seconds`, `.flush-fixed-delay`) and documented in `docs/modules/reporting.md`.

## Testing

- New `ReportCalculationDebouncerTest` covers coalescing, the rolling window, the max-wait cap, per-report independence, retry-on-failure, and shutdown flush (deterministic via injected `Clock`).
- `ReportDocumentChangeEventConsumerTest` extended with a happy-path test: only webhook-subscribed affected reports get a debounced trigger.
- Reporting e2e Cucumber scenarios (30) pass with the full Spring context. (A filtered local run trips the cross-module OpenAPI contract gate by design; the full CI suite covers it.)

Relates to #4 — this addresses the redundant-recalculation comments ("only run once for the final state of the DB"); the configurable changes-feed sync strategy from the issue description remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debounced automatic report recalculations: rapid document changes are coalesced into a single recalculation after updates settle.
  * Debounce behavior is configurable, with periodic flushing to keep results fresh during long-running imports.
* **Bug Fixes**
  * Reduced duplicate recalculations caused by bursty back-to-back updates.
* **Documentation**
  * Added an explanation of the debounce behavior and the related configuration options.
* **Chores**
  * Scheduled jobs now run on a dedicated thread pool for more consistent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->