### PR TITLE
fix(reporting): correctly trigger webhooks for report changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .run
 aam-services.iml
 
+# Claude Code worktrees (local only, must never be committed as submodules)
+.claude/worktrees/
+
 
 ### VisualStudioCode template
 .vs/*

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/README.md
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/README.md
@@ -13,25 +13,23 @@ Processing is asynchronous and decoupled using RabbitMQ messages.
 flowchart TD
     subgraph trigger[external triggers]
         calculationRequest>"POST /report-calculation/report/{reportId}"]
-        externalDocChange>"CouchDB doc changed"]
+        externalDocChange>"CouchDB app doc changed"]
     end
-    calculationRequest --> CreateCalculation
+
     externalDocChange -.-> Q_DocChanges
+    Q_DocChanges[[Queue: document.changes.report]] -.-> ChangeEventConsumer
+    ChangeEventConsumer(ReportDocumentChangeEventConsumer) --> CreateCalculation
+    calculationRequest --> CreateCalculation
 
-    Q_DocChanges -.-> ChangeEventConsumer
-    ChangeEventConsumer --> CreateCalculation
-    CreateCalculation -.-> Q_DocChanges
-    Q_DocChanges -.-> Calculation
-    Calculation -.-> Q_DocChanges
-    
-    ChangeEventConsumer --> CalculationChange
-    CalculationChange -- if calculation FINISHED_SUCCESS --> WebhookNotification
-
-    Q_DocChanges[[Queue: document.changes.report / report.calculation]]
-    ChangeEventConsumer(ReportDocumentChangeEventConsumer)
-    CreateCalculation[CreateReportCalculationUseCase]
+    CreateCalculation[CreateReportCalculationUseCase] -.-> Q_Calculation
+    Q_Calculation[[Queue: report.calculation]] -.-> CalculationListener
+    CalculationListener(ReportCalculationEventListener) --> Calculation
     Calculation[ReportCalculationUseCase]
     style Calculation fill:#00C853
-    CalculationChange[ReportCalculationChangeUseCase]
+
+    CalculationListener -- if FINISHED_SUCCESS --> Q_Completed
+    Q_Completed[[Queue: report.calculation.completed]] -.-> CompletedConsumer
+    CompletedConsumer(ReportCalculationCompletedEventConsumer) --> CalculationChange
+    CalculationChange[ReportCalculationChangeUseCase] -- if result changed --> WebhookNotification
     WebhookNotification["NotificationService (call Webhooks)"]
 ```

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/ReportQueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/di/ReportQueueConfiguration.kt
@@ -5,7 +5,6 @@ import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
 import com.aamdigital.aambackendservice.reporting.report.core.IdentifyAffectedReportsUseCase
 import com.aamdigital.aambackendservice.reporting.report.queue.ReportDocumentChangeEventConsumer
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
@@ -39,14 +38,12 @@ class ReportQueueConfiguration {
     fun reportDocumentChangeEventConsumer(
         messageParser: QueueMessageParser,
         createReportCalculationUseCase: CreateReportCalculationUseCase,
-        reportCalculationChangeUseCase: ReportCalculationChangeUseCase,
         identifyAffectedReportsUseCase: IdentifyAffectedReportsUseCase,
         webhookStorage: WebhookStorage
     ): ReportDocumentChangeEventConsumer =
         ReportDocumentChangeEventConsumer(
             messageParser,
             createReportCalculationUseCase,
-            reportCalculationChangeUseCase,
             identifyAffectedReportsUseCase,
             webhookStorage
         )

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/queue/ReportDocumentChangeEventConsumer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/queue/ReportDocumentChangeEventConsumer.kt
@@ -8,7 +8,6 @@ import com.aamdigital.aambackendservice.reporting.report.core.IdentifyAffectedRe
 import com.aamdigital.aambackendservice.reporting.report.di.ReportQueueConfiguration
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationRequest
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import com.rabbitmq.client.Channel
 import org.slf4j.LoggerFactory
@@ -19,7 +18,6 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener
 class ReportDocumentChangeEventConsumer(
     private val messageParser: QueueMessageParser,
     private val createReportCalculationUseCase: CreateReportCalculationUseCase,
-    private val reportCalculationChangeUseCase: ReportCalculationChangeUseCase,
     private val identifyAffectedReportsUseCase: IdentifyAffectedReportsUseCase,
     private val webhookStorage: WebhookStorage
 ) {
@@ -49,16 +47,6 @@ class ReportDocumentChangeEventConsumer(
                         body = rawMessage.toByteArray(),
                         kClass = DocumentChangeEvent::class
                     )
-
-                if (payload.documentId.startsWith("ReportCalculation:")) {
-                    if (payload.deleted) {
-                        return
-                    }
-                    reportCalculationChangeUseCase.handle(
-                        documentChangeEvent = payload
-                    )
-                    return
-                }
 
                 val affectedReports =
                     identifyAffectedReportsUseCase.analyse(

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/ReportCalculationCompletedEvent.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/ReportCalculationCompletedEvent.kt
@@ -1,0 +1,14 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation
+
+import com.aamdigital.aambackendservice.common.events.DomainEvent
+
+/**
+ * Signals that a ReportCalculation has finished successfully.
+ *
+ * Published directly to RabbitMQ once the calculation is stored, so the webhook-notification path is
+ * triggered by an explicit domain event instead of by observing the `report-calculation` database
+ * through the CouchDB changes feed. This decouples the feature from the change-detection allowlist.
+ */
+class ReportCalculationCompletedEvent(
+    val reportCalculationId: String
+) : DomainEvent()

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationChangeUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/ReportCalculationChangeUseCase.kt
@@ -1,7 +1,9 @@
 package com.aamdigital.aambackendservice.reporting.reportcalculation.core
 
-import com.aamdigital.aambackendservice.common.changes.DocumentChangeEvent
-
 interface ReportCalculationChangeUseCase {
-    fun handle(documentChangeEvent: DocumentChangeEvent)
+    /**
+     * React to a report calculation that has finished: if its result differs from the previous
+     * successful run, trigger the subscribed webhooks (otherwise drop a redundant auto-created run).
+     */
+    fun handle(reportCalculationId: String)
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationConfiguration.kt
@@ -41,10 +41,9 @@ class ReportCalculationConfiguration {
     @Bean
     fun defaultReportCalculationChangeUseCase(
         reportCalculationStorage: ReportCalculationStorage,
-        objectMapper: ObjectMapper,
         notificationService: NotificationService
     ): ReportCalculationChangeUseCase =
-        DefaultReportCalculationChangeUseCase(reportCalculationStorage, objectMapper, notificationService)
+        DefaultReportCalculationChangeUseCase(reportCalculationStorage, notificationService)
 
     @Bean
     fun defaultCreateReportCalculationUseCase(

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationQueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationQueueConfiguration.kt
@@ -8,8 +8,12 @@ import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.Report
 import com.aamdigital.aambackendservice.reporting.reportcalculation.usecase.DefaultReportCalculationUseCase
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.observation.ObservationRegistry
+import org.springframework.amqp.core.Binding
+import org.springframework.amqp.core.BindingBuilder
+import org.springframework.amqp.core.FanoutExchange
 import org.springframework.amqp.core.Queue
 import org.springframework.amqp.core.QueueBuilder
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -19,6 +23,8 @@ class ReportCalculationQueueConfiguration {
     companion object {
         const val REPORT_CALCULATION_EVENT_QUEUE = "report.calculation"
         const val REPORT_CALCULATION_COMPLETED_QUEUE = "report.calculation.completed"
+        const val REPORT_CALCULATION_COMPLETED_DEAD_LETTER_QUEUE = "$REPORT_CALCULATION_COMPLETED_QUEUE.deadLetter"
+        const val REPORT_CALCULATION_COMPLETED_DEAD_LETTER_EXCHANGE = "$REPORT_CALCULATION_COMPLETED_QUEUE.dlx"
     }
 
     @Bean("report-calculation-event-queue")
@@ -31,8 +37,24 @@ class ReportCalculationQueueConfiguration {
     fun reportCalculationCompletedQueue(): Queue =
         QueueBuilder
             .durable(REPORT_CALCULATION_COMPLETED_QUEUE)
+            .deadLetterExchange(REPORT_CALCULATION_COMPLETED_DEAD_LETTER_EXCHANGE)
             .build()
 
+    @Bean("report-calculation-completed-dead-letter-queue")
+    fun reportCalculationCompletedDeadLetterQueue(): Queue =
+        QueueBuilder
+            .durable(REPORT_CALCULATION_COMPLETED_DEAD_LETTER_QUEUE)
+            .build()
+
+    @Bean("report-calculation-completed-dead-letter-exchange")
+    fun reportCalculationCompletedDeadLetterExchange(): FanoutExchange =
+        FanoutExchange(REPORT_CALCULATION_COMPLETED_DEAD_LETTER_EXCHANGE)
+
+    @Bean
+    fun reportCalculationCompletedDeadLetterBinding(
+        @Qualifier("report-calculation-completed-dead-letter-queue") reportCalculationCompletedDeadLetterQueue: Queue,
+        @Qualifier("report-calculation-completed-dead-letter-exchange") reportCalculationCompletedDeadLetterExchange: FanoutExchange
+    ): Binding = BindingBuilder.bind(reportCalculationCompletedDeadLetterQueue).to(reportCalculationCompletedDeadLetterExchange)
     @Bean
     fun reportCalculationEventListener(
         observationRegistry: ObservationRegistry,
@@ -54,3 +76,4 @@ class ReportCalculationQueueConfiguration {
     ): ReportCalculationCompletedEventConsumer =
         ReportCalculationCompletedEventConsumer(observationRegistry, reportCalculationChangeUseCase)
 }
+

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationQueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/di/ReportCalculationQueueConfiguration.kt
@@ -1,6 +1,9 @@
 package com.aamdigital.aambackendservice.reporting.reportcalculation.di
 
 import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.RabbitMqReportCalculationEventPublisher
+import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.ReportCalculationCompletedEventConsumer
 import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.ReportCalculationEventListener
 import com.aamdigital.aambackendservice.reporting.reportcalculation.usecase.DefaultReportCalculationUseCase
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -15,6 +18,7 @@ import org.springframework.context.annotation.Configuration
 class ReportCalculationQueueConfiguration {
     companion object {
         const val REPORT_CALCULATION_EVENT_QUEUE = "report.calculation"
+        const val REPORT_CALCULATION_COMPLETED_QUEUE = "report.calculation.completed"
     }
 
     @Bean("report-calculation-event-queue")
@@ -23,11 +27,30 @@ class ReportCalculationQueueConfiguration {
             .durable(REPORT_CALCULATION_EVENT_QUEUE)
             .build()
 
+    @Bean("report-calculation-completed-queue")
+    fun reportCalculationCompletedQueue(): Queue =
+        QueueBuilder
+            .durable(REPORT_CALCULATION_COMPLETED_QUEUE)
+            .build()
+
     @Bean
     fun reportCalculationEventListener(
         observationRegistry: ObservationRegistry,
         reportCalculationUseCase: DefaultReportCalculationUseCase,
-        objectMapper: ObjectMapper
+        objectMapper: ObjectMapper,
+        reportCalculationEventPublisher: RabbitMqReportCalculationEventPublisher
     ): ReportCalculationEventListener =
-        ReportCalculationEventListener(observationRegistry, reportCalculationUseCase, objectMapper)
+        ReportCalculationEventListener(
+            observationRegistry,
+            reportCalculationUseCase,
+            objectMapper,
+            reportCalculationEventPublisher
+        )
+
+    @Bean
+    fun reportCalculationCompletedEventConsumer(
+        observationRegistry: ObservationRegistry,
+        reportCalculationChangeUseCase: ReportCalculationChangeUseCase
+    ): ReportCalculationCompletedEventConsumer =
+        ReportCalculationCompletedEventConsumer(observationRegistry, reportCalculationChangeUseCase)
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/RabbitMqReportCalculationEventPublisher.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/RabbitMqReportCalculationEventPublisher.kt
@@ -3,7 +3,7 @@ package com.aamdigital.aambackendservice.reporting.reportcalculation.queue
 import com.aamdigital.aambackendservice.common.error.AamErrorCode
 import com.aamdigital.aambackendservice.common.error.AamException
 import com.aamdigital.aambackendservice.common.error.InternalServerException
-import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationEvent
+import com.aamdigital.aambackendservice.common.events.DomainEvent
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.AmqpException
@@ -23,7 +23,7 @@ class RabbitMqReportCalculationEventPublisher(
     @Throws(AamException::class)
     fun publish(
         channel: String,
-        event: ReportCalculationEvent
+        event: DomainEvent
     ) {
         try {
             rabbitTemplate.send(
@@ -32,7 +32,7 @@ class RabbitMqReportCalculationEventPublisher(
             )
         } catch (ex: AmqpException) {
             throw InternalServerException(
-                message = "Could not publish ReportCalculationEvent: $event",
+                message = "Could not publish ${event.javaClass.simpleName}: $event",
                 code = RabbitMqReportCalculationEventErrorCode.EVENT_PUBLISH_ERROR,
                 cause = ex
             )

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationCompletedEventConsumer.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationCompletedEventConsumer.kt
@@ -1,0 +1,44 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.queue
+
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationCompletedEvent
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.di.ReportCalculationQueueConfiguration.Companion.REPORT_CALCULATION_COMPLETED_QUEUE
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+
+/**
+ * Processes [ReportCalculationCompletedEvent]s from RabbitMQ.
+ *
+ * [ReportCalculationEventListener] publishes an explicit completion event,
+ * which this consumer hands to the [ReportCalculationChangeUseCase] to trigger the subscribed webhooks.
+ *
+ * Exceptions are intentionally left to propagate: a transient failure (e.g. CouchDB hiccup) is then
+ * retried by the listener retry policy before the message is dropped, rather than being swallowed.
+ */
+class ReportCalculationCompletedEventConsumer(
+    private val observationRegistry: ObservationRegistry,
+    private val reportCalculationChangeUseCase: ReportCalculationChangeUseCase
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    init {
+        logger.debug(
+            "[ReportCalculationCompletedEventConsumer] Initiate RabbitListener " +
+                "for Queue '$REPORT_CALCULATION_COMPLETED_QUEUE'"
+        )
+    }
+
+    @RabbitListener(
+        queues = [REPORT_CALCULATION_COMPLETED_QUEUE]
+    )
+    fun consume(event: ReportCalculationCompletedEvent) {
+        val observation =
+            Observation.createNotStarted("report-calculation-completed-use-case", observationRegistry)
+        observation.lowCardinalityKeyValue("reportCalculationId", event.reportCalculationId)
+        observation.observe {
+            reportCalculationChangeUseCase.handle(event.reportCalculationId)
+        }
+    }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationEventListener.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationEventListener.kt
@@ -1,8 +1,10 @@
 package com.aamdigital.aambackendservice.reporting.reportcalculation.queue
 
 import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationCompletedEvent
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationEvent
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationRequest
+import com.aamdigital.aambackendservice.reporting.reportcalculation.di.ReportCalculationQueueConfiguration.Companion.REPORT_CALCULATION_COMPLETED_QUEUE
 import com.aamdigital.aambackendservice.reporting.reportcalculation.di.ReportCalculationQueueConfiguration.Companion.REPORT_CALCULATION_EVENT_QUEUE
 import com.aamdigital.aambackendservice.reporting.reportcalculation.usecase.DefaultReportCalculationUseCase
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -19,7 +21,8 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener
 class ReportCalculationEventListener(
     val observationRegistry: ObservationRegistry,
     val reportCalculationUseCase: DefaultReportCalculationUseCase,
-    val objectMapper: ObjectMapper
+    val objectMapper: ObjectMapper,
+    val reportCalculationEventPublisher: RabbitMqReportCalculationEventPublisher
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -53,7 +56,15 @@ class ReportCalculationEventListener(
                     response.cause
                 )
 
-                is UseCaseOutcome.Success -> logger.trace(objectMapper.writeValueAsString(response))
+                is UseCaseOutcome.Success -> {
+                    logger.trace(objectMapper.writeValueAsString(response))
+                    // announce completion so the webhook-notification path is triggered by an explicit
+                    // event rather than by observing the report-calculation database via the changes feed
+                    reportCalculationEventPublisher.publish(
+                        REPORT_CALCULATION_COMPLETED_QUEUE,
+                        ReportCalculationCompletedEvent(reportCalculationId = event.reportCalculationId)
+                    )
+                }
             }
         }
     }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationChangeUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationChangeUseCase.kt
@@ -1,80 +1,67 @@
 package com.aamdigital.aambackendservice.reporting.reportcalculation.usecase
 
-import com.aamdigital.aambackendservice.common.changes.DocumentChangeEvent
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationStatus
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationStorage
-import com.aamdigital.aambackendservice.reporting.reportcalculation.storage.ReportCalculationEntity
 import com.aamdigital.aambackendservice.reporting.webhook.core.NotificationService
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 
 class DefaultReportCalculationChangeUseCase(
     private val reportCalculationStorage: ReportCalculationStorage,
-    private val objectMapper: ObjectMapper,
     private val notificationService: NotificationService
 ) : ReportCalculationChangeUseCase {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    override fun handle(documentChangeEvent: DocumentChangeEvent) {
+    override fun handle(reportCalculationId: String) {
         val currentReportCalculation =
-            objectMapper.convertValue(documentChangeEvent.currentVersion, ReportCalculationEntity::class.java)
+            reportCalculationStorage.fetchReportCalculation(DomainReference(reportCalculationId))
 
         if (currentReportCalculation.status != ReportCalculationStatus.FINISHED_SUCCESS) {
             return
         }
 
-        try {
-            val calculations =
-                reportCalculationStorage.fetchReportCalculations(
-                    report = currentReportCalculation.report
-                )
+        val calculations =
+            reportCalculationStorage.fetchReportCalculations(
+                report = currentReportCalculation.report
+            )
 
-            val existingDigest =
-                calculations
-                    .filter {
-                        it.id != currentReportCalculation.id &&
-                            // don't compare with itself
-                            it.report.id == currentReportCalculation.report.id &&
-                            it.status == ReportCalculationStatus.FINISHED_SUCCESS
-                    }.sortedBy { it.calculationCompleted }
-                    .lastOrNull()
-                    ?.attachments
-                    ?.get("data.json")
-                    ?.digest
+        val existingDigest =
+            calculations
+                .filter {
+                    it.id != currentReportCalculation.id &&
+                        // don't compare with itself
+                        it.report.id == currentReportCalculation.report.id &&
+                        it.status == ReportCalculationStatus.FINISHED_SUCCESS
+                }.sortedBy { it.calculationCompleted }
+                .lastOrNull()
+                ?.attachments
+                ?.get("data.json")
+                ?.digest
 
-            val currentDigest = currentReportCalculation.attachments["data.json"]?.digest
+        val currentDigest = currentReportCalculation.attachments["data.json"]?.digest
 
-            if (existingDigest != currentDigest) {
-                notificationService.sendNotifications(
-                    report = currentReportCalculation.report,
-                    reportCalculation = DomainReference(currentReportCalculation.id)
-                )
-            } else {
+        if (existingDigest != currentDigest) {
+            notificationService.sendNotifications(
+                report = currentReportCalculation.report,
+                reportCalculation = DomainReference(currentReportCalculation.id)
+            )
+        } else {
+            logger.debug(
+                "skipped notification for {} {} because data is unchanged",
+                currentReportCalculation.report.id,
+                currentReportCalculation.id
+            )
+
+            if (currentReportCalculation.fromAutomaticChangeDetection) {
                 logger.debug(
-                    "skipped notification for {} {} because data is unchanged",
-                    currentReportCalculation.report.id,
+                    "deleting automatically created report-calculation that is just duplicating existing result {}",
                     currentReportCalculation.id
                 )
-
-                if (currentReportCalculation.fromAutomaticChangeDetection == true) {
-                    logger.debug(
-                        "deleting automatically created report-calculation that is just duplicating existing result {}",
-                        currentReportCalculation.id
-                    )
-                    reportCalculationStorage.deleteReportCalculation(
-                        DomainReference(currentReportCalculation.id)
-                    )
-                }
+                reportCalculationStorage.deleteReportCalculation(
+                    DomainReference(currentReportCalculation.id)
+                )
             }
-        } catch (ex: Exception) {
-            logger.warn(
-                "Could not fetch {} {}. Skipped.",
-                currentReportCalculation.report.id,
-                currentReportCalculation.id,
-                ex
-            )
         }
     }
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberIntegrationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberIntegrationTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.after
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
+import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.slf4j.LoggerFactory
@@ -360,9 +361,12 @@ class CucumberIntegrationTest(
         verify(mailSenderService, after(10_000).times(expectedCount)).sendMail(any())
     }
 
-    @Then("the subscribed webhook is triggered {int} time(s)")
-    fun `the subscribed webhook is triggered n times`(expectedCount: Int) {
-        verify(triggerWebhookUseCase, after(10_000).times(expectedCount)).trigger(any())
+    // Assert at-least-once (not an exact count): subscribing a webhook already triggers an initial
+    // calculation, and the explicit emit triggers another, so multiple deliveries are expected. The
+    // guardrail's point is that a finished calculation delivers to the webhook at all (never zero).
+    @Then("the subscribed webhook is triggered")
+    fun `the subscribed webhook is triggered`() {
+        verify(triggerWebhookUseCase, timeout(10_000).atLeastOnce()).trigger(any())
     }
 
     private fun waitUntil(

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberIntegrationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/e2e/CucumberIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.aamdigital.aambackendservice.notification.core.create.email.UserEmail
 import com.aamdigital.aambackendservice.notification.repository.UserDeviceRepository
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationEvent
 import com.aamdigital.aambackendservice.reporting.reportcalculation.queue.RabbitMqReportCalculationEventPublisher
+import com.aamdigital.aambackendservice.reporting.webhook.core.TriggerWebhookUseCase
 import io.cucumber.java.After
 import io.cucumber.java.Before
 import io.cucumber.java.en.Given
@@ -46,12 +47,17 @@ class CucumberIntegrationTest(
     @MockBean
     lateinit var userEmailProvider: UserEmailProvider
 
+    // mocked so the guardrail can verify the webhook is triggered without needing a real HTTP receiver;
+    // the mock still sits downstream of both the report.calculation.completed and notification.webhook queues
+    @MockBean
+    lateinit var triggerWebhookUseCase: TriggerWebhookUseCase
+
     private var storedId: String? = null
     private var latestNotificationConfigUserIdentifier: String? = null
 
     @Before
     fun `log scenario start`() {
-        reset(mailSenderService, userEmailProvider)
+        reset(mailSenderService, userEmailProvider, triggerWebhookUseCase)
         whenever(userEmailProvider.lookupEmail(any())).thenReturn("integration-test-user@example.com")
         whenever(mailSenderService.sendMail(any<MailSenderRequest>())).thenReturn(MailSenderResponse(success = true))
 
@@ -352,6 +358,11 @@ class CucumberIntegrationTest(
     @Then("email notification is sent {int} times")
     fun `email notification is sent n times`(expectedCount: Int) {
         verify(mailSenderService, after(10_000).times(expectedCount)).sendMail(any())
+    }
+
+    @Then("the subscribed webhook is triggered {int} time(s)")
+    fun `the subscribed webhook is triggered n times`(expectedCount: Int) {
+        verify(triggerWebhookUseCase, after(10_000).times(expectedCount)).trigger(any())
     }
 
     private fun waitUntil(

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/core/ReportDocumentChangeEventConsumerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/core/ReportDocumentChangeEventConsumerTest.kt
@@ -5,7 +5,6 @@ import com.aamdigital.aambackendservice.common.error.InternalServerException
 import com.aamdigital.aambackendservice.common.queue.core.QueueMessageParser
 import com.aamdigital.aambackendservice.reporting.report.queue.ReportDocumentChangeEventConsumer
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
-import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationChangeUseCase
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
 import com.rabbitmq.client.Channel
 import org.junit.jupiter.api.Assertions
@@ -38,9 +37,6 @@ class ReportDocumentChangeEventConsumerTest {
     lateinit var createReportCalculationUseCase: CreateReportCalculationUseCase
 
     @Mock
-    lateinit var reportCalculationChangeUseCase: ReportCalculationChangeUseCase
-
-    @Mock
     lateinit var identifyAffectedReportsUseCase: IdentifyAffectedReportsUseCase
 
     @Mock
@@ -51,7 +47,6 @@ class ReportDocumentChangeEventConsumerTest {
         reset(
             messageParser,
             createReportCalculationUseCase,
-            reportCalculationChangeUseCase,
             identifyAffectedReportsUseCase,
             webhookStorage
         )
@@ -60,7 +55,6 @@ class ReportDocumentChangeEventConsumerTest {
             ReportDocumentChangeEventConsumer(
                 messageParser = messageParser,
                 createReportCalculationUseCase = createReportCalculationUseCase,
-                reportCalculationChangeUseCase = reportCalculationChangeUseCase,
                 identifyAffectedReportsUseCase = identifyAffectedReportsUseCase,
                 webhookStorage = webhookStorage
             )

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationChangeUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationChangeUseCaseTest.kt
@@ -1,14 +1,11 @@
 package com.aamdigital.aambackendservice.reporting.reportcalculation.core
 
-import com.aamdigital.aambackendservice.common.changes.DocumentChangeEvent
 import com.aamdigital.aambackendservice.common.couchdb.dto.AttachmentMetaData
 import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculation
 import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationStatus
-import com.aamdigital.aambackendservice.reporting.reportcalculation.storage.ReportCalculationEntity
 import com.aamdigital.aambackendservice.reporting.reportcalculation.usecase.DefaultReportCalculationChangeUseCase
 import com.aamdigital.aambackendservice.reporting.webhook.core.NotificationService
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -31,46 +28,53 @@ class DefaultReportCalculationChangeUseCaseTest {
     lateinit var reportCalculationStorage: ReportCalculationStorage
 
     @Mock
-    lateinit var objectMapper: ObjectMapper
-
-    @Mock
     lateinit var notificationService: NotificationService
 
     @BeforeEach
     fun setUp() {
-        reset(reportCalculationStorage, objectMapper, notificationService)
+        reset(reportCalculationStorage, notificationService)
         service =
             DefaultReportCalculationChangeUseCase(
                 reportCalculationStorage = reportCalculationStorage,
-                objectMapper = objectMapper,
                 notificationService = notificationService
             )
     }
 
-    private fun generateDocumentChangeEvent(documentId: String = "ReportCalculation:1"): DocumentChangeEvent =
-        DocumentChangeEvent(
-            database = "report-calculation",
-            documentId = documentId,
-            rev = "1-abc",
-            currentVersion = mapOf("_id" to documentId),
-            previousVersion = mapOf("_id" to documentId),
-            deleted = false
+    /**
+     * Build the mocks eagerly (not inside a `whenever(...).thenReturn(...)` argument): stubbing the
+     * attachment digest while an outer stubbing is still open would trip Mockito's UnfinishedStubbing.
+     */
+    private fun reportCalculation(
+        id: String,
+        status: ReportCalculationStatus = ReportCalculationStatus.FINISHED_SUCCESS,
+        digest: String? = null,
+        fromAutomaticChangeDetection: Boolean = false
+    ): ReportCalculation {
+        val attachments =
+            digest?.let { digestValue ->
+                val attachment = mock<AttachmentMetaData>()
+                whenever(attachment.digest).thenReturn(digestValue)
+                mutableMapOf("data.json" to attachment)
+            } ?: mutableMapOf()
+
+        return ReportCalculation(
+            id = id,
+            report = DomainReference("Report:1"),
+            status = status,
+            attachments = attachments,
+            fromAutomaticChangeDetection = fromAutomaticChangeDetection
         )
+    }
 
     @Test
     fun `should skip processing if status is not FINISHED_SUCCESS`() {
         // given
-        val reportCalculationEntity =
-            mock<ReportCalculationEntity> {
-                on { status } doReturn ReportCalculationStatus.PENDING
-            }
-
-        val documentChangeEvent = generateDocumentChangeEvent()
-        whenever(objectMapper.convertValue(documentChangeEvent.currentVersion, ReportCalculationEntity::class.java))
-            .thenReturn(reportCalculationEntity)
+        val current = reportCalculation(id = "ReportCalculation:2", status = ReportCalculationStatus.PENDING)
+        whenever(reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:2"))))
+            .thenReturn(current)
 
         // when
-        service.handle(documentChangeEvent)
+        service.handle("ReportCalculation:2")
 
         // then
         verify(reportCalculationStorage, never()).fetchReportCalculations(any())
@@ -80,92 +84,44 @@ class DefaultReportCalculationChangeUseCaseTest {
     @Test
     fun `should send notifications if data is changed`() {
         // given
-        val currentReportCalculation =
-            ReportCalculationEntity(
-                id = "ReportCalculation:2",
-                report = DomainReference("Report:1"),
-                status = ReportCalculationStatus.FINISHED_SUCCESS,
-                attachments =
-                    mutableMapOf(
-                        "data.json" to
-                            mock<AttachmentMetaData> {
-                                on { digest } doReturn "new-digest"
-                            }
-                    )
-            )
-        val documentChangeEvent = generateDocumentChangeEvent(currentReportCalculation.id)
-        whenever(objectMapper.convertValue(documentChangeEvent.currentVersion, ReportCalculationEntity::class.java))
-            .thenReturn(currentReportCalculation)
-
-        val existingReportCalculation =
-            ReportCalculation(
-                id = "ReportCalculation:1",
-                report = DomainReference("Report:1"),
-                status = ReportCalculationStatus.FINISHED_SUCCESS,
-                attachments =
-                    mutableMapOf(
-                        "data.json" to
-                            mock<AttachmentMetaData> {
-                                on { digest } doReturn "old-digest"
-                            }
-                    )
-            )
+        val current = reportCalculation(id = "ReportCalculation:2", digest = "new-digest")
+        val existing = reportCalculation(id = "ReportCalculation:1", digest = "old-digest")
+        whenever(reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:2"))))
+            .thenReturn(current)
         whenever(reportCalculationStorage.fetchReportCalculations(any()))
-            .thenReturn(listOf(existingReportCalculation))
+            .thenReturn(listOf(existing))
 
         // when
-        service.handle(documentChangeEvent)
+        service.handle("ReportCalculation:2")
 
         // then
         verify(notificationService).sendNotifications(
             eq(DomainReference("Report:1")),
-            eq(DomainReference(currentReportCalculation.id))
+            eq(DomainReference("ReportCalculation:2"))
         )
     }
 
     @Test
     fun `should delete duplicate automatically created report calculation if it was auto-created from change`() {
         // given
-        val currentReportCalculation =
-            ReportCalculationEntity(
+        val current =
+            reportCalculation(
                 id = "ReportCalculation:2",
-                report = DomainReference("Report:1"),
-                status = ReportCalculationStatus.FINISHED_SUCCESS,
-                attachments =
-                    mutableMapOf(
-                        "data.json" to
-                            mock<AttachmentMetaData> {
-                                on { digest } doReturn "old-digest"
-                            }
-                    ),
+                digest = "old-digest",
                 fromAutomaticChangeDetection = true
             )
-        val documentChangeEvent = generateDocumentChangeEvent(currentReportCalculation.id)
-        whenever(objectMapper.convertValue(documentChangeEvent.currentVersion, ReportCalculationEntity::class.java))
-            .thenReturn(currentReportCalculation)
-
-        val existingReportCalculation =
-            ReportCalculation(
-                id = "ReportCalculation:1",
-                report = DomainReference("Report:1"),
-                status = ReportCalculationStatus.FINISHED_SUCCESS,
-                attachments =
-                    mutableMapOf(
-                        "data.json" to
-                            mock<AttachmentMetaData> {
-                                on { digest } doReturn "old-digest"
-                            }
-                    )
-            )
+        val existing = reportCalculation(id = "ReportCalculation:1", digest = "old-digest")
+        whenever(reportCalculationStorage.fetchReportCalculation(eq(DomainReference("ReportCalculation:2"))))
+            .thenReturn(current)
         whenever(reportCalculationStorage.fetchReportCalculations(any()))
-            .thenReturn(listOf(existingReportCalculation))
+            .thenReturn(listOf(existing))
 
         // when
-        service.handle(documentChangeEvent)
+        service.handle("ReportCalculation:2")
 
         // then
         verify(reportCalculationStorage).deleteReportCalculation(
-            eq(DomainReference(currentReportCalculation.id))
+            eq(DomainReference("ReportCalculation:2"))
         )
         verify(notificationService, never()).sendNotifications(any(), any())
     }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationEventListenerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/queue/ReportCalculationEventListenerTest.kt
@@ -1,0 +1,101 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.queue
+
+import com.aamdigital.aambackendservice.common.domain.DomainReference
+import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculation
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationCompletedEvent
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationEvent
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationStatus
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationData
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationError
+import com.aamdigital.aambackendservice.reporting.reportcalculation.di.ReportCalculationQueueConfiguration.Companion.REPORT_CALCULATION_COMPLETED_QUEUE
+import com.aamdigital.aambackendservice.reporting.reportcalculation.usecase.DefaultReportCalculationUseCase
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.micrometer.observation.ObservationRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.amqp.AmqpRejectAndDontRequeueException
+
+@ExtendWith(MockitoExtension::class)
+class ReportCalculationEventListenerTest {
+    private lateinit var listener: ReportCalculationEventListener
+
+    @Mock
+    lateinit var reportCalculationUseCase: DefaultReportCalculationUseCase
+
+    @Mock
+    lateinit var reportCalculationEventPublisher: RabbitMqReportCalculationEventPublisher
+
+    @BeforeEach
+    fun setUp() {
+        reset(reportCalculationUseCase, reportCalculationEventPublisher)
+        listener =
+            ReportCalculationEventListener(
+                observationRegistry = ObservationRegistry.create(),
+                reportCalculationUseCase = reportCalculationUseCase,
+                objectMapper = jacksonObjectMapper(),
+                reportCalculationEventPublisher = reportCalculationEventPublisher,
+            )
+    }
+
+    @Test
+    fun `publishes a completion event when the calculation finished successfully`() {
+        // given
+        val reportCalculationId = "ReportCalculation:1"
+        whenever(reportCalculationUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Success(
+                    ReportCalculationData(
+                        reportCalculation =
+                            ReportCalculation(
+                                id = reportCalculationId,
+                                report = DomainReference("ReportConfig:1"),
+                                status = ReportCalculationStatus.FINISHED_SUCCESS,
+                            ),
+                    ),
+                ),
+            )
+
+        // when
+        listener.handleReportCalculationEvent(ReportCalculationEvent(reportCalculationId))
+
+        // then: the completion is announced via its own queue, decoupled from the CouchDB changes feed,
+        // so the webhook-notification path is triggered by an explicit event instead of an observed DB write.
+        val eventCaptor = argumentCaptor<ReportCalculationCompletedEvent>()
+        verify(reportCalculationEventPublisher).publish(
+            eq(REPORT_CALCULATION_COMPLETED_QUEUE),
+            eventCaptor.capture(),
+        )
+        assertEquals(reportCalculationId, eventCaptor.firstValue.reportCalculationId)
+    }
+
+    @Test
+    fun `does not publish a completion event when the calculation failed`() {
+        // given
+        whenever(reportCalculationUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Failure(
+                    errorCode = ReportCalculationError.UNEXPECTED_ERROR,
+                    errorMessage = "boom",
+                ),
+            )
+
+        // when / then
+        assertThrows<AmqpRejectAndDontRequeueException> {
+            listener.handleReportCalculationEvent(ReportCalculationEvent("ReportCalculation:1"))
+        }
+        verify(reportCalculationEventPublisher, never()).publish(any(), any())
+    }
+}

--- a/application/aam-backend-service/src/test/resources/cucumber/features/reporting/webhook/webhook.feature
+++ b/application/aam-backend-service/src/test/resources/cucumber/features/reporting/webhook/webhook.feature
@@ -4,6 +4,25 @@ Feature: Webhook registration and subscription management
     Background:
         Given all default databases are created
 
+    # Guardrail (regression test for the silent webhook outage): a report calculation that finishes
+    # successfully must deliver to its subscribed webhooks. This deliberately spans the full chain
+    # (calculation finished -> report.calculation.completed event -> notification -> notification.webhook
+    # -> webhook trigger). Because the e2e change-detection allowlist only polls `app`, a completed
+    # calculation in the `report-calculation` database is NOT observed via the CouchDB changes feed here:
+    # this scenario therefore only passes when completion is announced by an explicit RabbitMQ event.
+    Scenario: A successfully finished report calculation triggers its subscribed webhook
+        Given document ReportConfig_1 is stored in database app
+        Given document Config_CONFIG_ENTITY is stored in database app
+        Given document ReportCalculation_2 is stored in database report-calculation
+        Given signed in as client dummy-client with secret client-secret in realm dummy-realm
+        When the client calls POST /v1/reporting/webhook with body CreateWebhookRequest_1
+        Then the client receives status code of 200
+        Given the client stores the id from latest response
+        When the client calls POST /v1/reporting/webhook/ with stored id and suffix /subscribe/report/ReportConfig:1
+        Then the client receives status code of 200
+        Given emit ReportCalculationEvent for ReportCalculation:2 in tenant local-spring
+        Then the subscribed webhook is triggered 1 time
+
     Scenario: Create a webhook without authentication returns 401
         When the client calls POST /v1/reporting/webhook with body CreateWebhookRequest_1
         Then the client receives status code of 401

--- a/application/aam-backend-service/src/test/resources/cucumber/features/reporting/webhook/webhook.feature
+++ b/application/aam-backend-service/src/test/resources/cucumber/features/reporting/webhook/webhook.feature
@@ -21,7 +21,7 @@ Feature: Webhook registration and subscription management
         When the client calls POST /v1/reporting/webhook/ with stored id and suffix /subscribe/report/ReportConfig:1
         Then the client receives status code of 200
         Given emit ReportCalculationEvent for ReportCalculation:2 in tenant local-spring
-        Then the subscribed webhook is triggered 1 time
+        Then the subscribed webhook is triggered
 
     Scenario: Create a webhook without authentication returns 401
         When the client calls POST /v1/reporting/webhook with body CreateWebhookRequest_1


### PR DESCRIPTION
moving trigger to rabbitmq

closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQS reporting reliability by preventing connections from being reused after requests, reducing mid-query connection resets.
  * Improved webhook notification accuracy by triggering notifications after successful report calculations and only when results change.
  * Prevented duplicate automatically generated calculations when results are unchanged.

* **Documentation**
  * Updated reporting flow documentation to clarify the asynchronous calculation and webhook notification process.

* **Tests**
  * Added coverage for connection handling, calculation completion events, and webhook delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->