### PR TITLE
chore: untrack .claude/worktrees gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code worktrees (local only, must never be committed as submodules)
+.claude/worktrees/
+
 .idea
 .run
 aam-services.iml


### PR DESCRIPTION
## Summary
- A git worktree directory (`.claude/worktrees/refactor-merge-io-exception-44`) was accidentally staged with a broad `git add` and committed to `main` as a submodule gitlink (index mode `160000`) in PR #152 (commits fa4679a/efa5fbe).
- There is no `.gitmodules` file in this repo, so CI's submodule handling breaks when it encounters this gitlink entry.
- This is a **forward-fix only** — no history rewrite. It untracks the gitlink from the index (`git rm --cached`) and adds `.claude/worktrees/` to `.gitignore` to prevent recurrence.

## Test plan
- [x] Verified `.gitignore` change ignores `.claude/worktrees/` going forward
- [x] Verified the offending gitlink entry (mode `160000`) is removed from the git index
- [x] Confirmed no `.gitmodules` file was added/needed (worktrees are local-only, not submodules)
- [ ] CI passes on this branch (no more submodule-handling errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)