### PR TITLE
feat(reporting): hard-wire metadata columns and enum options into SQS schema

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/ConfigurableEnumSchema.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/ConfigurableEnumSchema.kt
@@ -1,0 +1,42 @@
+package com.aamdigital.aambackendservice.reporting.report.sqs
+
+import com.aamdigital.aambackendservice.common.domain.EntityAttributeType
+
+/**
+ * ConfigurableEnum documents are defined in code (not in Config:CONFIG_ENTITY), so their
+ * SQS table and label-lookup view are hard-wired here rather than derived from app config.
+ */
+object ConfigurableEnumSchema {
+    /**
+     * Name of the hard-wired table exposing raw ConfigurableEnum documents
+     * (one row per enum, options as a JSON array in the "values" column).
+     */
+    const val TABLE = "ConfigurableEnum"
+
+    val FIELDS =
+        TableFields(
+            mapOf(
+                "_id" to EntityAttributeType(field = "_id", type = "TEXT"),
+                "values" to EntityAttributeType(field = "values", type = "TEXT")
+            )
+        )
+
+    /**
+     * One row per enum option, so report queries can translate stored option ids
+     * into human-readable labels with a plain JOIN instead of json_each boilerplate:
+     *
+     * SELECT c.name, COALESCE(g.label, c.gender) AS gender
+     * FROM Child c
+     * LEFT JOIN ConfigurableEnumOption g
+     *   ON g.enum_id = 'genders' AND g.option_id = c.gender
+     *
+     * SQS executes any statement listed in sql.indexes, which lets us ship this view
+     * as part of the schema definition.
+     */
+    const val OPTION_VIEW =
+        "CREATE VIEW IF NOT EXISTS ConfigurableEnumOption AS " +
+            "SELECT REPLACE(ec._id, 'ConfigurableEnum:', '') AS enum_id, " +
+            "json_extract(o.value, '$.id') AS option_id, " +
+            "json_extract(o.value, '$.label') AS label " +
+            "FROM ConfigurableEnum ec, json_each(ec.\"values\") o"
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaService.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaService.kt
@@ -77,31 +77,6 @@ class SqsSchemaService(
         private const val FILENAME_CONFIG_ENTITY = "Config:CONFIG_ENTITY"
         private const val SCHEMA_PATH = "_design/sqlite:config"
         private const val TARGET_DATABASE = "app"
-
-        /**
-         * Name of the hard-wired table exposing raw ConfigurableEnum documents
-         * (one row per enum, options as a JSON array in the "values" column).
-         */
-        const val CONFIGURABLE_ENUM_TABLE = "ConfigurableEnum"
-
-        /**
-         * One row per enum option, so report queries can translate stored option ids
-         * into human-readable labels with a plain JOIN instead of json_each boilerplate:
-         *
-         * SELECT c.name, COALESCE(g.label, c.gender) AS gender
-         * FROM Child c
-         * LEFT JOIN ConfigurableEnumOption g
-         *   ON g.enum_id = 'genders' AND g.option_id = c.gender
-         *
-         * SQS executes any statement listed in sql.indexes, which lets us ship this view
-         * as part of the schema definition.
-         */
-        const val CONFIGURABLE_ENUM_OPTION_VIEW =
-            "CREATE VIEW IF NOT EXISTS ConfigurableEnumOption AS " +
-                "SELECT REPLACE(ec._id, 'ConfigurableEnum:', '') AS enum_id, " +
-                "json_extract(o.value, '$.id') AS option_id, " +
-                "json_extract(o.value, '$.label') AS label " +
-                "FROM ConfigurableEnum ec, json_each(ec.\"values\") o"
     }
 
     fun getSchemaPath(): String = "/$TARGET_DATABASE/$SCHEMA_PATH"
@@ -183,7 +158,7 @@ class SqsSchemaService(
                 }
                 // hard-wired last, so it wins over a manually configured entity:ConfigurableEnum
                 // (the old workaround that required adding this entity to the config document)
-                .plus(getConfigurableEnumTable())
+                .plus(Pair(ConfigurableEnumSchema.TABLE, ConfigurableEnumSchema.FIELDS))
 
         return SqsSchema(
             sql =
@@ -196,25 +171,10 @@ class SqsSchemaService(
                                 separator = ":"
                             )
                         ),
-                    indexes = listOf(CONFIGURABLE_ENUM_OPTION_VIEW)
+                    indexes = listOf(ConfigurableEnumSchema.OPTION_VIEW)
                 )
         )
     }
-
-    /**
-     * ConfigurableEnum documents are defined in code (not in Config:CONFIG_ENTITY),
-     * so their table is hard-wired here to make enum options queryable at all times.
-     */
-    private fun getConfigurableEnumTable(): Pair<String, TableFields> =
-        Pair(
-            CONFIGURABLE_ENUM_TABLE,
-            TableFields(
-                mapOf(
-                    "_id" to EntityAttributeType(field = "_id", type = "TEXT"),
-                    "values" to EntityAttributeType(field = "values", type = "TEXT")
-                )
-            )
-        )
 
     private fun mapConfigDataTypeToSqsDataType(dataType: String): String =
         when (dataType) {

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaService.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaService.kt
@@ -77,6 +77,31 @@ class SqsSchemaService(
         private const val FILENAME_CONFIG_ENTITY = "Config:CONFIG_ENTITY"
         private const val SCHEMA_PATH = "_design/sqlite:config"
         private const val TARGET_DATABASE = "app"
+
+        /**
+         * Name of the hard-wired table exposing raw ConfigurableEnum documents
+         * (one row per enum, options as a JSON array in the "values" column).
+         */
+        const val CONFIGURABLE_ENUM_TABLE = "ConfigurableEnum"
+
+        /**
+         * One row per enum option, so report queries can translate stored option ids
+         * into human-readable labels with a plain JOIN instead of json_each boilerplate:
+         *
+         * SELECT c.name, COALESCE(g.label, c.gender) AS gender
+         * FROM Child c
+         * LEFT JOIN ConfigurableEnumOption g
+         *   ON g.enum_id = 'genders' AND g.option_id = c.gender
+         *
+         * SQS executes any statement listed in sql.indexes, which lets us ship this view
+         * as part of the schema definition.
+         */
+        const val CONFIGURABLE_ENUM_OPTION_VIEW =
+            "CREATE VIEW IF NOT EXISTS ConfigurableEnumOption AS " +
+                "SELECT REPLACE(ec._id, 'ConfigurableEnum:', '') AS enum_id, " +
+                "json_extract(o.value, '$.id') AS option_id, " +
+                "json_extract(o.value, '$.label') AS label " +
+                "FROM ConfigurableEnum ec, json_each(ec.\"values\") o"
     }
 
     fun getSchemaPath(): String = "/$TARGET_DATABASE/$SCHEMA_PATH"
@@ -156,6 +181,9 @@ class SqsSchemaService(
                 }.associate {
                     Pair(it.first, TableFields(it.second))
                 }
+                // hard-wired last, so it wins over a manually configured entity:ConfigurableEnum
+                // (the old workaround that required adding this entity to the config document)
+                .plus(getConfigurableEnumTable())
 
         return SqsSchema(
             sql =
@@ -168,10 +196,25 @@ class SqsSchemaService(
                                 separator = ":"
                             )
                         ),
-                    indexes = emptyList()
+                    indexes = listOf(CONFIGURABLE_ENUM_OPTION_VIEW)
                 )
         )
     }
+
+    /**
+     * ConfigurableEnum documents are defined in code (not in Config:CONFIG_ENTITY),
+     * so their table is hard-wired here to make enum options queryable at all times.
+     */
+    private fun getConfigurableEnumTable(): Pair<String, TableFields> =
+        Pair(
+            CONFIGURABLE_ENUM_TABLE,
+            TableFields(
+                mapOf(
+                    "_id" to EntityAttributeType(field = "_id", type = "TEXT"),
+                    "values" to EntityAttributeType(field = "values", type = "TEXT")
+                )
+            )
+        )
 
     private fun mapConfigDataTypeToSqsDataType(dataType: String): String =
         when (dataType) {
@@ -207,29 +250,31 @@ class SqsSchemaService(
                     type = "TEXT"
                 )
             ),
+            // "_" prefix marks columns that are derived from internal metadata rather than
+            // configured entity fields, and avoids clashes with custom fields of the same name
             EntityAttribute(
-                "created_at",
+                "_created_at",
                 EntityAttributeType(
                     field = "created.at",
                     type = "DATE"
                 )
             ),
             EntityAttribute(
-                "created_by",
+                "_created_by",
                 EntityAttributeType(
                     field = "created.by",
                     type = "TEXT"
                 )
             ),
             EntityAttribute(
-                "updated_at",
+                "_updated_at",
                 EntityAttributeType(
                     field = "updated.at",
                     type = "DATE"
                 )
             ),
             EntityAttribute(
-                "updated_by",
+                "_updated_by",
                 EntityAttributeType(
                     field = "updated.by",
                     type = "TEXT"

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorage.kt
@@ -31,6 +31,7 @@ class DefaultReportStorage(
     private val objectMapper: ObjectMapper
 ) : ReportStorage {
     private val legacyMigration = ReportConfigLegacyMigration(couchDbClient)
+    private val columnRenameMigration = ReportColumnRenameMigration(couchDbClient)
 
     companion object {
         private const val REPORT_DATABASE = "app"
@@ -52,7 +53,7 @@ class DefaultReportStorage(
 
         return response.rows
             .filter { isSqlReport(it.doc) }
-            .map { normalizeRawDocToReport(it.doc) }
+            .map { columnRenameMigration.migrate(normalizeRawDocToReport(it.doc)) }
     }
 
     @Throws(
@@ -81,10 +82,14 @@ class DefaultReportStorage(
             )
         }
 
-        val report = normalizeRawDocToReport(rawDoc)
+        val rawReport = normalizeRawDocToReport(rawDoc)
+        val report = columnRenameMigration.migrate(rawReport)
 
         if (legacyMigration.isLegacyDoc(rawDoc)) {
+            // the legacy write-back already persists the report with renamed columns
             legacyMigration.tryWriteMigratedDoc(rawDoc, report)
+        } else if (report != rawReport) {
+            columnRenameMigration.tryWriteRenamedDoc(rawDoc)
         }
 
         return report

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/ReportColumnRenameMigration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/ReportColumnRenameMigration.kt
@@ -1,0 +1,117 @@
+package com.aamdigital.aambackendservice.reporting.report.storage
+
+import com.aamdigital.aambackendservice.common.couchdb.core.CouchDbClient
+import com.aamdigital.aambackendservice.reporting.report.Report
+import com.aamdigital.aambackendservice.reporting.report.ReportItem
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+import org.slf4j.LoggerFactory
+
+/**
+ * Transitional migration for the rename of the hard-wired SQS metadata columns
+ * (created_at, created_by, updated_at, updated_by) to their "_" prefixed variants
+ * (see SqsSchemaService.getDefaultEntityAttributes).
+ *
+ * Queries in stored ReportConfig documents are rewritten in memory on every read, so report
+ * execution keeps working immediately after the schema rename. On single-report reads the
+ * rewritten document is also written back to CouchDB, so the stored config (and what admins
+ * see in the report editor) converges to the new column names.
+ *
+ * The rewrite is idempotent: the word-boundary regex does not match names that already carry
+ * the "_" prefix (or any other word character around them, e.g. custom columns like
+ * "my_created_at"). Occurrences inside string literals would be rewritten too; that is
+ * acceptable because the old column names are only meaningful as column references.
+ *
+ * TODO: verify against production data whether any existing ReportConfig actually uses the old
+ *  column names (created_at, created_by, updated_at, updated_by; check "created_by" especially,
+ *  it was never documented). If no stored report uses them, this migration and its wiring in
+ *  DefaultReportStorage can be removed and only the schema rename kept.
+ */
+class ReportColumnRenameMigration(
+    private val couchDbClient: CouchDbClient
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val REPORT_DATABASE = "app"
+
+        private val COLUMN_RENAMES =
+            listOf(
+                Regex("\\bcreated_at\\b") to "_created_at",
+                Regex("\\bcreated_by\\b") to "_created_by",
+                Regex("\\bupdated_at\\b") to "_updated_at",
+                Regex("\\bupdated_by\\b") to "_updated_by"
+            )
+    }
+
+    /**
+     * Returns a copy of the report with all queries rewritten to the new column names.
+     * Returns the same instance if nothing needed rewriting.
+     */
+    fun migrate(report: Report): Report {
+        val migratedItems = report.items.map { migrateItem(it) }
+        if (migratedItems == report.items) {
+            return report
+        }
+        return report.copy(items = migratedItems)
+    }
+
+    /**
+     * Persists the rewritten queries of a canonical ReportConfig document back to CouchDB,
+     * keeping all other document fields untouched.
+     */
+    fun tryWriteRenamedDoc(rawDoc: ObjectNode) {
+        val documentId = rawDoc.get("_id")?.textValue() ?: return
+        rewriteQueryNodes(rawDoc.get("reportDefinition"))
+        try {
+            couchDbClient.putDatabaseDocument(
+                database = REPORT_DATABASE,
+                documentId = documentId,
+                body = rawDoc
+            )
+            logger.info("Renamed deprecated SQS metadata columns in ReportConfig {}", documentId)
+        } catch (ex: Exception) {
+            logger.warn(
+                "Write-back of renamed SQS metadata columns failed for ReportConfig {}: {}",
+                documentId,
+                ex.message
+            )
+        }
+    }
+
+    fun rewriteSql(sql: String): String =
+        COLUMN_RENAMES.fold(sql) { result, (regex, replacement) ->
+            regex.replace(result, replacement)
+        }
+
+    private fun migrateItem(item: ReportItem): ReportItem =
+        when (item) {
+            is ReportItem.ReportQuery -> {
+                val rewritten = rewriteSql(item.sql)
+                if (rewritten == item.sql) item else ReportItem.ReportQuery(sql = rewritten)
+            }
+
+            is ReportItem.ReportGroup -> {
+                val migratedItems = item.items.map { migrateItem(it) }
+                if (migratedItems == item.items) item else item.copy(items = migratedItems)
+            }
+        }
+
+    private fun rewriteQueryNodes(node: JsonNode?) {
+        if (node == null) {
+            return
+        }
+        if (node.isArray) {
+            node.forEach { rewriteQueryNodes(it) }
+            return
+        }
+        if (node is ObjectNode) {
+            val query = node.get("query")
+            if (query != null && query.isTextual) {
+                node.set<JsonNode>("query", TextNode(rewriteSql(query.textValue())))
+            }
+            rewriteQueryNodes(node.get("items"))
+        }
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
@@ -103,7 +103,7 @@ class SqsSchemaServiceTest {
         assertThat(enumFields.getValue("values").field).isEqualTo("values")
         assertThat(enumFields).containsKey("_id")
 
-        assertThat(schema.sql.indexes).containsExactly(SqsSchemaService.CONFIGURABLE_ENUM_OPTION_VIEW)
+        assertThat(schema.sql.indexes).containsExactly(ConfigurableEnumSchema.OPTION_VIEW)
     }
 
     @Test

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
@@ -17,6 +17,8 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+private const val SCHEMA_DOC_ID = "_design/sqlite:config"
+
 @ExtendWith(MockitoExtension::class)
 class SqsSchemaServiceTest {
     private lateinit var service: SqsSchemaService
@@ -42,21 +44,21 @@ class SqsSchemaServiceTest {
         whenever(
             couchDbClient.getDatabaseDocument(
                 database = eq("app"),
-                documentId = eq("_design/sqlite:config"),
+                documentId = eq(SCHEMA_DOC_ID),
                 queryParams = any(),
                 kClass = eq(SqsSchema::class)
             )
         ).thenAnswer { throw NotFoundException(message = "not found", code = TestErrorCode.TEST_EXCEPTION) }
         whenever(
             couchDbClient.putDatabaseDocument(any(), any(), any())
-        ).thenReturn(DocSuccess(ok = true, id = "_design/sqlite:config", rev = "1-new"))
+        ).thenReturn(DocSuccess(ok = true, id = SCHEMA_DOC_ID, rev = "1-new"))
     }
 
     private fun capturePublishedSchema(): SqsSchema {
         val bodyCaptor = argumentCaptor<Any>()
         verify(couchDbClient).putDatabaseDocument(
             database = eq("app"),
-            documentId = eq("_design/sqlite:config"),
+            documentId = eq(SCHEMA_DOC_ID),
             body = bodyCaptor.capture()
         )
         return bodyCaptor.firstValue as SqsSchema
@@ -80,7 +82,10 @@ class SqsSchemaServiceTest {
 
         // then
         val schema = capturePublishedSchema()
-        val childFields = schema.sql.tables.getValue("Child").fields
+        val childFields =
+            schema.sql.tables
+                .getValue("Child")
+                .fields
 
         assertThat(childFields.getValue("_created_at").field).isEqualTo("created.at")
         assertThat(childFields.getValue("_created_by").field).isEqualTo("created.by")
@@ -91,7 +96,10 @@ class SqsSchemaServiceTest {
         // real entity fields stay unprefixed
         assertThat(childFields).containsKeys("name", "inactive", "anonymized")
 
-        val enumFields = schema.sql.tables.getValue("ConfigurableEnum").fields
+        val enumFields =
+            schema.sql.tables
+                .getValue("ConfigurableEnum")
+                .fields
         assertThat(enumFields.getValue("values").field).isEqualTo("values")
         assertThat(enumFields).containsKey("_id")
 
@@ -115,7 +123,11 @@ class SqsSchemaServiceTest {
         service.updateSchema()
 
         // then: hard-wired definition wins, no metadata columns are mixed in
-        val enumFields = capturePublishedSchema().sql.tables.getValue("ConfigurableEnum").fields
+        val enumFields =
+            capturePublishedSchema()
+                .sql.tables
+                .getValue("ConfigurableEnum")
+                .fields
         assertThat(enumFields.keys).containsExactlyInAnyOrder("_id", "values")
     }
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsSchemaServiceTest.kt
@@ -1,0 +1,121 @@
+package com.aamdigital.aambackendservice.reporting.report.sqs
+
+import com.aamdigital.aambackendservice.common.couchdb.core.CouchDbClient
+import com.aamdigital.aambackendservice.common.couchdb.dto.DocSuccess
+import com.aamdigital.aambackendservice.common.domain.TestErrorCode
+import com.aamdigital.aambackendservice.common.error.NotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class SqsSchemaServiceTest {
+    private lateinit var service: SqsSchemaService
+
+    @Mock
+    lateinit var couchDbClient: CouchDbClient
+
+    @BeforeEach
+    fun setUp() {
+        reset(couchDbClient)
+        service = SqsSchemaService(couchDbClient)
+    }
+
+    private fun stubConfig(data: Map<String, AppConfigEntry>) {
+        whenever(
+            couchDbClient.getDatabaseDocument(
+                database = eq("app"),
+                documentId = eq("Config:CONFIG_ENTITY"),
+                queryParams = any(),
+                kClass = eq(AppConfigFile::class)
+            )
+        ).thenReturn(AppConfigFile(id = "Config:CONFIG_ENTITY", rev = "1-abc", data = data))
+        whenever(
+            couchDbClient.getDatabaseDocument(
+                database = eq("app"),
+                documentId = eq("_design/sqlite:config"),
+                queryParams = any(),
+                kClass = eq(SqsSchema::class)
+            )
+        ).thenAnswer { throw NotFoundException(message = "not found", code = TestErrorCode.TEST_EXCEPTION) }
+        whenever(
+            couchDbClient.putDatabaseDocument(any(), any(), any())
+        ).thenReturn(DocSuccess(ok = true, id = "_design/sqlite:config", rev = "1-new"))
+    }
+
+    private fun capturePublishedSchema(): SqsSchema {
+        val bodyCaptor = argumentCaptor<Any>()
+        verify(couchDbClient).putDatabaseDocument(
+            database = eq("app"),
+            documentId = eq("_design/sqlite:config"),
+            body = bodyCaptor.capture()
+        )
+        return bodyCaptor.firstValue as SqsSchema
+    }
+
+    @Test
+    fun `should emit prefixed metadata columns, hard-wired ConfigurableEnum table and option view`() {
+        // given
+        stubConfig(
+            mapOf(
+                "entity:Child" to
+                    AppConfigEntry(
+                        label = "Child",
+                        attributes = mapOf("name" to AppConfigAttribute(dataType = "string"))
+                    )
+            )
+        )
+
+        // when
+        service.updateSchema()
+
+        // then
+        val schema = capturePublishedSchema()
+        val childFields = schema.sql.tables.getValue("Child").fields
+
+        assertThat(childFields.getValue("_created_at").field).isEqualTo("created.at")
+        assertThat(childFields.getValue("_created_by").field).isEqualTo("created.by")
+        assertThat(childFields.getValue("_updated_at").field).isEqualTo("updated.at")
+        assertThat(childFields.getValue("_updated_by").field).isEqualTo("updated.by")
+        // the old unprefixed column names are gone
+        assertThat(childFields).doesNotContainKeys("created_at", "created_by", "updated_at", "updated_by")
+        // real entity fields stay unprefixed
+        assertThat(childFields).containsKeys("name", "inactive", "anonymized")
+
+        val enumFields = schema.sql.tables.getValue("ConfigurableEnum").fields
+        assertThat(enumFields.getValue("values").field).isEqualTo("values")
+        assertThat(enumFields).containsKey("_id")
+
+        assertThat(schema.sql.indexes).containsExactly(SqsSchemaService.CONFIGURABLE_ENUM_OPTION_VIEW)
+    }
+
+    @Test
+    fun `should override a manually configured ConfigurableEnum entity with the hard-wired table`() {
+        // given: old workaround where entity:ConfigurableEnum was added to the config document
+        stubConfig(
+            mapOf(
+                "entity:ConfigurableEnum" to
+                    AppConfigEntry(
+                        label = "ConfigurableEnum",
+                        attributes = mapOf("values" to AppConfigAttribute(dataType = ""))
+                    )
+            )
+        )
+
+        // when
+        service.updateSchema()
+
+        // then: hard-wired definition wins, no metadata columns are mixed in
+        val enumFields = capturePublishedSchema().sql.tables.getValue("ConfigurableEnum").fields
+        assertThat(enumFields.keys).containsExactlyInAnyOrder("_id", "values")
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorageTest.kt
@@ -288,6 +288,47 @@ class DefaultReportStorageTest {
         verify(couchDbClient, never()).putDatabaseDocument(any(), any(), any())
     }
 
+    // --- Deprecated metadata column rename ---
+
+    @Test
+    fun `should rewrite deprecated metadata columns on read and write renamed doc back`() {
+        // given
+        stubFetchDoc(
+            """
+            {
+              "_id": "ReportConfig:rename",
+              "_rev": "1-abc",
+              "title": "Rename",
+              "mode": "sql",
+              "reportDefinition": [
+                { "query": "SELECT name, created_at FROM Child" }
+              ]
+            }
+            """.trimIndent()
+        )
+        stubWriteBack()
+
+        // when
+        val report = storage.fetchReport(DomainReference("ReportConfig:rename"))
+
+        // then
+        assertThat((report.items[0] as ReportItem.ReportQuery).sql)
+            .isEqualTo("SELECT name, _created_at FROM Child")
+
+        val bodyCaptor = argumentCaptor<Any>()
+        verify(couchDbClient).putDatabaseDocument(
+            database = eq("app"),
+            documentId = eq("ReportConfig:rename"),
+            body = bodyCaptor.capture()
+        )
+        val writtenDoc = bodyCaptor.firstValue as ObjectNode
+        assertThat(writtenDoc.get("reportDefinition").get(0).get("query").textValue())
+            .isEqualTo("SELECT name, _created_at FROM Child")
+        // untouched fields survive the write-back
+        assertThat(writtenDoc.get("_rev").textValue()).isEqualTo("1-abc")
+        assertThat(writtenDoc.get("title").textValue()).isEqualTo("Rename")
+    }
+
     // --- Non-SQL report ---
 
     @Test

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/DefaultReportStorageTest.kt
@@ -322,8 +322,13 @@ class DefaultReportStorageTest {
             body = bodyCaptor.capture()
         )
         val writtenDoc = bodyCaptor.firstValue as ObjectNode
-        assertThat(writtenDoc.get("reportDefinition").get(0).get("query").textValue())
-            .isEqualTo("SELECT name, _created_at FROM Child")
+        val writtenQuery =
+            writtenDoc
+                .get("reportDefinition")
+                .get(0)
+                .get("query")
+                .textValue()
+        assertThat(writtenQuery).isEqualTo("SELECT name, _created_at FROM Child")
         // untouched fields survive the write-back
         assertThat(writtenDoc.get("_rev").textValue()).isEqualTo("1-abc")
         assertThat(writtenDoc.get("title").textValue()).isEqualTo("Rename")

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/ReportColumnRenameMigrationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/storage/ReportColumnRenameMigrationTest.kt
@@ -1,0 +1,59 @@
+package com.aamdigital.aambackendservice.reporting.report.storage
+
+import com.aamdigital.aambackendservice.common.couchdb.core.CouchDbClient
+import com.aamdigital.aambackendservice.reporting.report.Report
+import com.aamdigital.aambackendservice.reporting.report.ReportItem
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class ReportColumnRenameMigrationTest {
+    @Mock
+    lateinit var couchDbClient: CouchDbClient
+
+    private val migration by lazy { ReportColumnRenameMigration(couchDbClient) }
+
+    @Test
+    fun `should rewrite all deprecated column names but leave prefixed and custom names untouched`() {
+        val rewritten =
+            migration.rewriteSql(
+                "SELECT c.created_at, c.created_by, c.updated_at, c.updated_by, " +
+                    "c._created_at, c.my_created_at, c.created_at_old " +
+                    "FROM Child c WHERE created_at BETWEEN \$startDate AND \$endDate"
+            )
+
+        assertThat(rewritten).isEqualTo(
+            "SELECT c._created_at, c._created_by, c._updated_at, c._updated_by, " +
+                "c._created_at, c.my_created_at, c.created_at_old " +
+                "FROM Child c WHERE _created_at BETWEEN \$startDate AND \$endDate"
+        )
+        // idempotent: applying the rewrite again changes nothing
+        assertThat(migration.rewriteSql(rewritten)).isEqualTo(rewritten)
+    }
+
+    @Test
+    fun `should migrate queries in nested groups and return same instance when nothing changes`() {
+        val report =
+            Report(
+                id = "ReportConfig:test",
+                title = "Test",
+                items =
+                    listOf(
+                        ReportItem.ReportGroup(
+                            title = "group",
+                            items = listOf(ReportItem.ReportQuery(sql = "SELECT created_at FROM Child"))
+                        )
+                    )
+            )
+
+        val migrated = migration.migrate(report)
+
+        val group = migrated.items[0] as ReportItem.ReportGroup
+        assertThat((group.items[0] as ReportItem.ReportQuery).sql).isEqualTo("SELECT _created_at FROM Child")
+        // a report without deprecated names is passed through unchanged
+        assertThat(migration.migrate(migrated)).isSameAs(migrated)
+    }
+}


### PR DESCRIPTION
- closes #156
- closes #161 :question: 

## What this does

**1. Rename built-in metadata columns to `_`-prefixed names**

The SQS schema hard-wires columns derived from internal entity metadata into every table. These are renamed to mark their internal origin and prevent clashes with custom fields of the same name:

| old | new | source field |
| --- | --- | --- |
| `created_at` | `_created_at` | `created.at` |
| `created_by` | `_created_by` | `created.by` |
| `updated_at` | `_updated_at` | `updated.at` |
| `updated_by` | `_updated_by` | `updated.by` |

`inactive` and `anonymized` are real entity fields (defined in the Entity class), so they stay unprefixed. `_id`, `_rev`, `_attachments` were already prefixed.

**2. Migrate stored report queries**

`ReportColumnRenameMigration` rewrites the old column names in stored `ReportConfig` queries (word-boundary match, idempotent, logged). Queries are rewritten in memory on every read, so report execution keeps working immediately after the upgrade; on single-report reads the renamed document is also written back to CouchDB. Works for both canonical and legacy v1 documents.

Note: there is a TODO in the migration class to verify against production data whether any stored report actually uses the old names. If none do, the migration wiring can be dropped and only the schema rename kept.

**3. Hard-wire ConfigurableEnum into the SQS schema**

- A `ConfigurableEnum` table (`_id`, `values`) is always part of the generated schema now, so the manual workaround of adding `entity:ConfigurableEnum` to the config document is no longer needed (a manually configured entry is overridden).
- A `ConfigurableEnumOption` view (shipped via `sql.indexes`, which SQS executes as arbitrary statements) exposes one row per dropdown option (`enum_id`, `option_id`, `label`). Reports can translate stored option ids into human-readable labels with a plain JOIN:

```sql
SELECT c.name, COALESCE(g.label, c.gender) AS gender
FROM Child c
LEFT JOIN ConfigurableEnumOption g
  ON g.enum_id = 'genders' AND g.option_id = c.gender
```

Since the schema hash (`configVersion`) covers tables and indexes, SQS re-ingests once after deployment; the first report calculation after the upgrade is slower.

A companion ndb-core PR updates the reporting documentation (built-in columns, enum label recipe, SQL snippets from the shared GoogleDoc).

## Manual Testing Steps

Tested end-to-end on the local developer docker stack (backend built from this branch):

1. Report with the new columns (`SELECT name, _created_at, _created_by, _updated_at FROM Child ORDER BY _created_at DESC`) returns data and sorts correctly.
2. Enum label join via `ConfigurableEnumOption` view returns human-readable labels (`male` / `female` / ...).
3. A report still using old `created_at` executes successfully and its stored document is rewritten to `_created_at` after the run.
4. Date-range filter `WHERE _created_at BETWEEN $startDate AND $endDate` returns the expected count.
5. A legacy v1 report document (`aggregationDefinition` with `created_at`) executes and is migrated to canonical form with the renamed column.
6. Generated `_design/sqlite:config` contains the prefixed columns (old names gone), the `ConfigurableEnum` table and the view statement in `indexes`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added consistent SQS schema support for configurable enum fields, including an option view to normalize stored enum options.
  - Ensures the configurable enum table definition is present and takes precedence over any manually provided variant.

- **Bug Fixes**
  - Legacy reports using old metadata column names are automatically rewritten to underscore-prefixed versions on read, and the updated definition is persisted back safely.

- **Tests**
  - Added coverage for schema generation/overrides and report migration behavior (including nested query structures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->