### PR TITLE
docs(reporting): document generated SQS schema and fix report docs link

### DIFF
--- a/docs/modules/reporting.md
+++ b/docs/modules/reporting.md
@@ -41,12 +41,41 @@ You should also account for that possibility.
     - or, if it was already enabled, re-up the docker compose and confirm the new containers and environment are running
 3. Create `ReportConfig:` entities to define specific reports
     - the API / backend reports only support the `"mode": "sql"`
-    - for details on report definitions,
-      see https://aam-digital.github.io/ndb-core/documentation/additional-documentation/how-to-guides/create-a-report.html
+    - for details on report definitions, the available tables and columns and useful SQL recipes,
+      see https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/reports.html
 4. Make sure the users who are supposed to access the reports in the frontend have permission to view `ReportConfig`
    entities
 5. Within the app, users can now execute sql-based reports and see calculated results (configuration for the view in
    Config:CONFIG_ENTITY `"view:report": {"component": "Reporting"}`)
+
+## SQL schema
+
+The schema handed to SQS is generated from `Config:CONFIG_ENTITY` (see `SqsSchemaService`): every configured entity type
+becomes a table with one column per configured field. On top of that, the backend hard-wires the following, so reports
+can use them without any config change:
+
+- **Default columns in every table** (`getDefaultEntityAttributes`): `_id`, `_rev`, `_attachments`, `_created_at`,
+  `_created_by`, `_updated_at`, `_updated_by`, `inactive`, `anonymized`.
+  The `_` prefix marks columns generated from internal document metadata (e.g. `_created_at` reads `created.at`) and
+  avoids clashes with configured fields of the same name. `inactive` and `anonymized` stay unprefixed because they are
+  regular entity fields.
+- **`ConfigurableEnum` table** (`_id`, `values`), one row per dropdown definition with its options as a JSON array.
+- **`ConfigurableEnumOption` view** (`enum_id`, `option_id`, `label`), one row per dropdown option, shipped as part of
+  `sql.indexes` (see `ConfigurableEnumSchema`). Report queries translate a stored option id into its human-readable
+  label with a plain JOIN:
+
+```sql
+SELECT c.name, COALESCE(g.label, c.gender) AS gender
+FROM Child c
+LEFT JOIN ConfigurableEnumOption g
+  ON g.enum_id = 'genders' AND g.option_id = c.gender
+```
+
+The schema hash (`configVersion`) covers tables and indexes, so changing any of this makes SQS re-ingest the database
+once after deployment. The first report calculation after such a change is therefore slower than usual.
+
+For the full list of query recipes and examples,
+see https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/reports.html
 
 ## API access to reports
 

--- a/docs/modules/reporting.md
+++ b/docs/modules/reporting.md
@@ -51,15 +51,16 @@ You should also account for that possibility.
 ## SQL schema
 
 The schema handed to SQS is generated from `Config:CONFIG_ENTITY` (see `SqsSchemaService`): every configured entity type
-becomes a table with one column per configured field. On top of that, the backend hard-wires the following, so reports
-can use them without any config change:
+becomes a table with one column per configured field, except fields of dataType `file`, which are skipped. The backend
+additionally hard-wires the following, so reports can use them without any config change:
 
-- **Default columns in every table** (`getDefaultEntityAttributes`): `_id`, `_rev`, `_attachments`, `_created_at`,
-  `_created_by`, `_updated_at`, `_updated_by`, `inactive`, `anonymized`.
+- **Default columns in every generated entity table** (`getDefaultEntityAttributes`): `_id`, `_rev`, `_attachments`,
+  `_created_at`, `_created_by`, `_updated_at`, `_updated_by`, `inactive`, `anonymized`.
   The `_` prefix marks columns generated from internal document metadata (e.g. `_created_at` reads `created.at`) and
   avoids clashes with configured fields of the same name. `inactive` and `anonymized` stay unprefixed because they are
   regular entity fields.
-- **`ConfigurableEnum` table** (`_id`, `values`), one row per dropdown definition with its options as a JSON array.
+- **`ConfigurableEnum` table**, with only the columns `_id` and `values` (the default columns above do not apply to it),
+  one row per dropdown definition with its options as a JSON array.
 - **`ConfigurableEnumOption` view** (`enum_id`, `option_id`, `label`), one row per dropdown option, shipped as part of
   `sql.indexes` (see `ConfigurableEnumSchema`). Report queries translate a stored option id into its human-readable
   label with a plain JOIN:


### PR DESCRIPTION
- part of #161

Documentation only, no code changes.

#160 hard-wired parts of the SQS schema into the backend, but this repository never described the generated schema at all. A new `## SQL schema` section in `docs/modules/reporting.md` documents:

- the default columns added to every table (`_id`, `_rev`, `_attachments`, `_created_at`, `_created_by`, `_updated_at`, `_updated_by`, `inactive`, `anonymized`), where they come from, and why some are `_`-prefixed while others are not
- the hard-wired `ConfigurableEnum` table and the `ConfigurableEnumOption` view, with the JOIN that turns a stored dropdown option id into its human-readable label
- the effect on `configVersion`: changing tables or indexes makes SQS re-ingest once after deployment, so the first report calculation is slower

The link to the frontend report documentation is also repointed. The companion PR Aam-Digital/ndb-core#4159 moves that page from the how-to guides to the concepts section, which renames its URL:

```
how-to-guides/create-a-report.html   ->   concepts/reports.html
```

Note on merge order: the new URL only exists once Aam-Digital/ndb-core#4159 is merged and the documentation site is rebuilt.

## Manual Testing Steps

1. Review the rendered `docs/modules/reporting.md` in the "Files changed" tab.
2. The documented columns and view match the merged implementation in `SqsSchemaService.getDefaultEntityAttributes()` and `ConfigurableEnumSchema`.
3. The `ConfigurableEnumOption` join example is the one verified end-to-end on the developer docker stack in #160.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reporting setup guidance with a link to report concepts.
  * Added SQL schema documentation, including generated schema details, configurable enum handling, example queries, and configuration versioning.
  * Added a link to reporting query recipes and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->