### PR TITLE
fix(reporting): better logging (reportId) for invalid SQL queries

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/core/QueryStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/core/QueryStorage.kt
@@ -4,5 +4,5 @@ import com.aamdigital.aambackendservice.reporting.report.sqs.QueryRequest
 import java.io.InputStream
 
 interface QueryStorage {
-    fun executeQuery(query: QueryRequest): InputStream
+    fun executeQuery(query: QueryRequest, reportId: String): InputStream
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorage.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorage.kt
@@ -34,7 +34,7 @@ class SqsQueryStorage(
         private const val MAX_ERROR_BODY_LENGTH = 500
     }
 
-    override fun executeQuery(query: QueryRequest): InputStream {
+    override fun executeQuery(query: QueryRequest, reportId: String): InputStream {
         val schemaPath = schemaService.getSchemaPath()
         schemaService.updateSchema()
 
@@ -51,13 +51,13 @@ class SqsQueryStorage(
                 // opaque, untyped HttpClientErrorException
                 .onStatus({ it.is4xxClientError }) { _, clientResponse ->
                     throw InvalidArgumentException(
-                        message = "[SqsQueryStorage] SQS rejected the query " +
+                        message = "[SqsQueryStorage] SQS rejected the query for report '$reportId' " +
                             "(${clientResponse.statusCode}): ${readErrorBody(clientResponse)}",
                         code = SqsQueryStorageErrorCode.QUERY_FAILED,
                     )
                 }.onStatus({ it.is5xxServerError }) { _, clientResponse ->
                     throw ExternalSystemException(
-                        message = "[SqsQueryStorage] SQS failed to execute the query " +
+                        message = "[SqsQueryStorage] SQS failed to execute the query for report '$reportId' " +
                             "(${clientResponse.statusCode}): ${readErrorBody(clientResponse)}",
                         code = SqsQueryStorageErrorCode.QUERY_EXECUTION_FAILED,
                     )
@@ -65,7 +65,7 @@ class SqsQueryStorage(
 
         if (response == null) {
             throw ExternalSystemException(
-                message = "[SqsQueryStorage] Could not fetch response from SQS",
+                message = "[SqsQueryStorage] Could not fetch response from SQS for report '$reportId'",
                 code = SqsQueryStorageErrorCode.EMPTY_RESPONSE
             )
         }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/usecase/DefaultReportCalculationUseCase.kt
@@ -120,6 +120,7 @@ class DefaultReportCalculationUseCase(
             if (singleBareQuery) {
                 listOf(
                     handleReportItems(
+                        reportId = report.id,
                         queries = report.items,
                         reportCalculation = reportCalculation
                     )
@@ -128,6 +129,7 @@ class DefaultReportCalculationUseCase(
                 listOf(
                     "[".byteInputStream(),
                     handleReportItems(
+                        reportId = report.id,
                         queries = report.items,
                         reportCalculation = reportCalculation
                     ),
@@ -148,6 +150,7 @@ class DefaultReportCalculationUseCase(
     }
 
     private fun handleReportItems(
+        reportId: String,
         queries: List<ReportItem>,
         reportCalculation: ReportCalculation
     ): InputStream {
@@ -158,14 +161,15 @@ class DefaultReportCalculationUseCase(
                         is ReportItem.ReportQuery -> {
                             val queryResult =
                                 queryStorage.executeQuery(
-                                    handleReportQuery(queryItem, reportCalculation)
+                                    handleReportQuery(queryItem, reportCalculation),
+                                    reportId
                                 )
                             mutableListOf(queryResult)
                         }
 
                         is ReportItem.ReportGroup -> {
                             val prefix = "{\"${queryItem.title}\":[".byteInputStream()
-                            val queryResult = handleReportItems(queryItem.items, reportCalculation)
+                            val queryResult = handleReportItems(reportId, queryItem.items, reportCalculation)
                             val suffix = "]}".byteInputStream()
                             mutableListOf(prefix, queryResult, suffix)
                         }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
@@ -36,31 +36,35 @@ class SqsQueryStorageTest {
     fun `should return the response stream on success`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""[{"foo":1}]"""))
 
-        val result = storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()))
+        val result = storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()), "Report:1")
 
         assertThat(result.readBytes().decodeToString()).isEqualTo("""[{"foo":1}]""")
     }
 
     @Test
-    fun `should throw InvalidArgumentException carrying the SQS body on 4xx (invalid query)`() {
+    fun `should throw InvalidArgumentException carrying the SQS body and report id on 4xx (invalid query)`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(400).setBody("no such column: foo"))
 
-        val thrown = catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList())) }
+        val thrown =
+            catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()), "Report:1") }
 
         assertThat(thrown).isInstanceOf(InvalidArgumentException::class.java)
         assertThat((thrown as InvalidArgumentException).code)
             .isEqualTo(SqsQueryStorage.SqsQueryStorageErrorCode.QUERY_FAILED)
         assertThat(thrown.message).contains("no such column: foo")
+        assertThat(thrown.message).contains("Report:1")
     }
 
     @Test
-    fun `should throw ExternalSystemException on 5xx`() {
+    fun `should throw ExternalSystemException carrying the report id on 5xx`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("internal error"))
 
-        val thrown = catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList())) }
+        val thrown =
+            catchThrowable { storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()), "Report:1") }
 
         assertThat(thrown).isInstanceOf(ExternalSystemException::class.java)
         assertThat((thrown as ExternalSystemException).code)
             .isEqualTo(SqsQueryStorage.SqsQueryStorageErrorCode.QUERY_EXECUTION_FAILED)
+        assertThat(thrown.message).contains("Report:1")
     }
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
@@ -41,6 +41,7 @@ class SqsQueryStorageTest {
         result.use { response ->
             assertThat(response.readBytes().decodeToString()).isEqualTo("""[{"foo":1}]""")
         }
+    }
 
     @Test
     fun `should throw InvalidArgumentException carrying the SQS body and report id on 4xx (invalid query)`() {

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/report/sqs/SqsQueryStorageTest.kt
@@ -38,8 +38,9 @@ class SqsQueryStorageTest {
 
         val result = storage.executeQuery(QueryRequest("SELECT foo FROM bar", emptyList()), "Report:1")
 
-        assertThat(result.readBytes().decodeToString()).isEqualTo("""[{"foo":1}]""")
-    }
+        result.use { response ->
+            assertThat(response.readBytes().decodeToString()).isEqualTo("""[{"foo":1}]""")
+        }
 
     @Test
     fun `should throw InvalidArgumentException carrying the SQS body and report id on 4xx (invalid query)`() {

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/core/DefaultReportCalculationUseCaseTest.kt
@@ -161,7 +161,7 @@ class DefaultReportCalculationUseCaseTest {
         whenever(reportCalculationStorage.storeCalculation(any())).thenAnswer { i -> i.arguments[0] }
 
         val rootCause = RuntimeException("connection reset")
-        whenever(queryStorage.executeQuery(any())).thenAnswer { throw rootCause }
+        whenever(queryStorage.executeQuery(any(), any())).thenAnswer { throw rootCause }
 
         // when
         val response =
@@ -223,7 +223,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -257,7 +257,8 @@ class DefaultReportCalculationUseCaseTest {
                             "2010-01-16T23:59:59.999Z"
                         )
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -307,7 +308,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -341,7 +342,8 @@ class DefaultReportCalculationUseCaseTest {
                             "2010-01-16T23:59:59.999Z"
                         )
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -391,7 +393,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -427,7 +429,8 @@ class DefaultReportCalculationUseCaseTest {
                             "2010-01-16T23:59:59.999Z"
                         )
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -466,7 +469,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -491,7 +494,8 @@ class DefaultReportCalculationUseCaseTest {
                     query = "SELECT name FROM foo",
                     args = emptyList()
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -535,7 +539,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -569,7 +573,8 @@ class DefaultReportCalculationUseCaseTest {
                             DEFAULT_TO_DATE
                         )
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -613,7 +618,7 @@ class DefaultReportCalculationUseCaseTest {
             )
         ).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any())).thenReturn("[{}]".byteInputStream())
+        whenever(queryStorage.executeQuery(any(), any())).thenReturn("[{}]".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any()))
             .thenAnswer { i -> i.arguments[0] }
@@ -638,7 +643,8 @@ class DefaultReportCalculationUseCaseTest {
                     query = "SELECT * FROM foo WHERE time BETWEEN ? and ?",
                     args = listOf("2024-01-15", "2024-04-30T23:59:59.999Z")
                 )
-            )
+            ),
+            eq("Report:1")
         )
     }
 
@@ -659,7 +665,7 @@ class DefaultReportCalculationUseCaseTest {
 
         whenever(reportStorage.fetchReport(eq(DomainReference("Report:1")))).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any()))
+        whenever(queryStorage.executeQuery(any(), any()))
             .thenReturn("""[{"name":"Alice"},{"name":"Bob"}]""".byteInputStream())
 
         whenever(reportCalculationStorage.storeCalculation(any())).thenAnswer { i -> i.arguments[0] }
@@ -699,7 +705,7 @@ class DefaultReportCalculationUseCaseTest {
 
         whenever(reportStorage.fetchReport(eq(DomainReference("Report:1")))).thenReturn(report)
 
-        whenever(queryStorage.executeQuery(any()))
+        whenever(queryStorage.executeQuery(any(), any()))
             .thenReturn(
                 """[{"name":"Alice"}]""".byteInputStream(),
                 """[{"age":5}]""".byteInputStream()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for failed or empty report queries now include the relevant report ID, making issues easier to identify.
  * Report IDs are consistently retained when processing queries, including nested report groups and multiple-query reports.

* **Tests**
  * Expanded coverage for report ID handling across successful, failed, single-query, multi-query, legacy, and argument-free scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->