### PR TITLE
ci: fix qlty coverage upload path mapping

### DIFF
--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -48,16 +48,18 @@ jobs:
           password: ${{ secrets.GHCR_PULL_SECRET }}
 
       - name: Run Tests and generate Jacoco Test Report
-        env:
-          JACOCO_SOURCE_PATH: application/aam-backend-service/src/main/kotlin
         run: |
           ./gradlew jacocoTestReport --no-daemon
 
-      - uses: qltysh/qlty-action/coverage@v2
+      - name: Upload coverage to Qlty
+        uses: qltysh/qlty-action/coverage@v2
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-          files: "**/build/reports/jacoco/test/jacocoTestReport.xml"
+          files: application/aam-backend-service/build/reports/jacoco/test/jacocoTestReport.xml
           format: jacoco
+          # JaCoCo XML records paths relative to the source root
+          # (com/aamdigital/...), so prefix them to make them repo-relative.
+          add-prefix: application/aam-backend-service/src/main/kotlin
 
   build:
     strategy:


### PR DESCRIPTION
## Problem

Coverage upload to qlty was already configured (added in 5c1b85f, Sept 2025) but has been **failing on every run since**, silently. From the last `main` run ([30826318635](https://github.com/Aam-Digital/aam-services/actions/runs/30826318635)):

```
227 unique code file paths
227 paths are missing on disk (100.0%)

Missing code files:
  com/aamdigital/aambackendservice/Application.kt
  com/aamdigital/aambackendservice/common/actuator/FeatureRegistrar.kt
  ...
TIP: Consider using add-prefix or strip-prefix to fix paths
ERROR
```

It went unnoticed because `qlty-action` defaults to `skip-errors: true` — the step logs `##[error]` but the job still reports success.

## Cause

JaCoCo XML records paths relative to the *source root* (`com/aamdigital/…`), not the repo root. The workflow tried to correct this with `JACOCO_SOURCE_PATH`, which the qlty CLI genuinely does honor ([`jacoco.rs`](https://github.com/qltysh/qlty/blob/main/qlty-coverage/src/parser/jacoco.rs)) — but it was set as step-level `env:` on the **Gradle** step, so the qlty step never saw it. Gradle itself ignores that variable, so it did nothing at all.

## Fix

Drop the dead env var and use the action's `add-prefix` input, matching the [qlty Kotlin example](https://github.com/qltysh/example-kotlin). Also pin `files:` to the module path — a repo-wide `**/` glob paired with a module-specific prefix would silently mis-prefix a second Gradle module if one were added.

## Verification

Ran the qlty CLI locally against the same JaCoCo report (same 227 unique paths as CI, so it's a faithful proxy):

| | missing paths |
|---|---|
| before | 227 / 227 (100.0%) |
| after | 2 / 227 (0.9%) — line coverage 74.71%, validation `exit=0` |

The 2 remaining are `Comparisons.kt`, a Kotlin compiler synthetic filename with no file on disk — harmless and well under the validation threshold.

## Not included

- **`skip-errors: false`** on the coverage step — the only reason a 100% path failure survived ~11 months is that it doesn't fail the job. Happy to add if wanted.
- **`keycloak-third-party-authentication`** has no test job at all, so no coverage. Adding one is more than a config fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test coverage reporting.
  * Updated coverage report uploads for more reliable source-path mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->