### PR TITLE
fix(keycloak): build the third-party-authentication SPI against Keycloak 26.7.1

### DIFF
--- a/application/aam-backend-service/gradle/libs.versions.toml
+++ b/application/aam-backend-service/gradle/libs.versions.toml
@@ -22,7 +22,9 @@ jacoco = "0.8.15"
 
 # --- runtime ---
 # keycloak-admin-client follows its own release train, which stops at 26.0.x and does not
-# track the Keycloak server version (26.4.7, pinned in the SPI module's pom.xml).
+# track the Keycloak server version (26.7.1, pinned in the SPI module's pom.xml). Nothing
+# newer exists: 26.1.0 onwards were never published for this artifact, so 26.0.x is the
+# whole line and matching the server version is not possible.
 keycloakAdminClient = "26.0.11"
 firebaseAdmin = "9.10.0"
 postgresql = "42.7.13"

--- a/application/keycloak-third-party-authentication/docker-compose.yml
+++ b/application/keycloak-third-party-authentication/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: keycloak
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.7.1
     volumes:
       - ./data/keycloak/data:/opt/keycloak/data
       - ./data/keycloak/themes:/opt/keycloak/themes

--- a/application/keycloak-third-party-authentication/pom.xml
+++ b/application/keycloak-third-party-authentication/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <keycloak.version>26.4.7</keycloak.version>
+        <keycloak.version>26.7.1</keycloak.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/docs/developer/docker-compose.yml
+++ b/docs/developer/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   # ***************************************************************
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.7.1
     container_name: keycloak
     depends_on:
       db-keycloak:


### PR DESCRIPTION
Aligns aam-services with the Keycloak 26.7.1 server upgrade (Aam-Digital/keycloak-aam#4, image side in Aam-Digital/keycloak-aam#5).

## What changed

- `keycloak.version` in the SPI module's `pom.xml`: 26.4.7 to 26.7.1
- the two dev stack compose files move to the same version, so a local stack matches what is deployed rather than lagging a release behind

## Why, and why it is not urgent

The SPI compiles against `keycloak-server-spi-private`, which carries no cross-version compatibility guarantee, so keeping the declared version aligned with the deployed server is what keeps the built jar trustworthy.

That said, I measured the actual behaviour before assuming the worst: the currently released jar, built against 26.4.7, **runs cleanly on 26.7.1**. I verified the full partner SSO login against a 26.7.1 server, and the extension registered, called the backend, resolved the user and issued an authorization code. So this alignment is hygiene, not a fix for a live problem, and it does not gate the server upgrade.

## Verification

- The SPI module builds against 26.7.1 (`mvn clean package` in the module's build container, BUILD SUCCESS).
- The released 0.2.3 jar was exercised end to end on a 26.7.1 server, including the third-party session flow and the token claims the platform depends on (`sub`, `username` from `exact_username`, `_couchdb.roles`).
- CI covers the test suite side.

## Not in this PR, deliberately

**The e2e stack's `KeycloakContainer` is still unpinned.** `TestContainers.kt` constructs it with no image reference, so it runs whatever version the testcontainers module defaults to, and `TestImages.kt` has no Keycloak entry even though every other container there is pinned for Renovate. That means an upstream Keycloak release can change what this suite authenticates against with no PR in our repos.

Worth fixing, but pinning it is a behaviour change for the suite rather than a version bump: 26.7 tightened admin role checks and changed several representations, so it deserves its own PR where a CI failure does not block the server upgrade. Ideally it would point at our own `keycloak-aam` image so the tests run against what we actually ship, which additionally needs that package granted to this repository for CI to pull it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the integrated Keycloak platform to version 26.7.1.
  * Applied the upgrade consistently across authentication and developer environments.
  * Updated related integration configuration to align with the newer Keycloak release.
  * Documented the corresponding compatibility information for the authentication service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->