### PR TITLE
fix(common): bound the PostgreSQL socket timeout and group database errors in Sentry

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
@@ -1,0 +1,51 @@
+package com.aamdigital.aambackendservice.common.storage.di
+
+import io.sentry.EventProcessor
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import org.springframework.stereotype.Component
+
+/**
+ * Gives database errors a Sentry grouping key that stays stable across occurrences.
+ *
+ * Hibernate logs SQL failures at ERROR through [SQL_EXCEPTION_LOGGER] *before* the exception
+ * propagates, so they become Sentry events even though the only code path that reaches them -
+ * the scheduled jobs wrapped in
+ * [com.aamdigital.aambackendservice.common.scheduling.ScheduledJobBackoff] - already catches,
+ * backs off and retries. The service therefore recovers on its own; what it does not do is
+ * report the failure as one recurring fault.
+ *
+ * HikariCP interpolates the elapsed wait and the pool counts into its message
+ * ("... request timed out after 37386ms (total=7, active=0, idle=6, waiting=0)"), so no two
+ * occurrences look alike and a single fault spreads across new Sentry issues as it recurs. That
+ * splits the per-issue event counts which `archived_until_escalating` uses to decide whether to
+ * escalate, so a recurring fault can stay archived while tracking real production outages.
+ *
+ * Replacing digit runs in the message collapses the interpolated variants into one issue while
+ * keeping genuinely different SQL errors (constraint violations and the like) apart.
+ */
+@Component
+class DatabaseSentryEventProcessor : EventProcessor {
+    override fun process(
+        event: SentryEvent,
+        hint: Hint
+    ): SentryEvent {
+        if (event.logger != SQL_EXCEPTION_LOGGER) {
+            return event
+        }
+
+        // The logback integration always sets `formatted`; the others are defensive fallbacks.
+        val message = event.message?.formatted ?: event.message?.message ?: event.throwable?.message
+
+        if (message != null) {
+            event.fingerprints = listOf(SQL_EXCEPTION_LOGGER, message.replace(INTERPOLATED_NUMBERS, "#"))
+        }
+
+        return event
+    }
+
+    companion object {
+        const val SQL_EXCEPTION_LOGGER = "org.hibernate.engine.jdbc.spi.SqlExceptionHelper"
+        private val INTERPOLATED_NUMBERS = Regex("\\d+")
+    }
+}

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -26,6 +26,23 @@ spring:
           writetimeout: 10000
   datasource:
     driver-class-name: org.postgresql.Driver
+    hikari:
+      data-source-properties:
+        # pgjdbc's socketTimeout is the only JDBC/pool timeout that is not already bounded by a
+        # default: HikariCP supplies connectionTimeout=30s, validationTimeout=5s, maxLifetime=30min
+        # and keepaliveTime=2min, and pgjdbc supplies connectTimeout=10s. Without socketTimeout a
+        # read on a half-open socket blocks until the OS gives up retransmitting (~15 min on Linux),
+        # so the scheduled jobs stall silently instead of failing and being retried by
+        # ScheduledJobBackoff.
+        #
+        # THIS VALUE IS IN SECONDS - unlike every millisecond-based HikariCP setting above it.
+        # 30s leaves a wide margin: everything stored in PostgreSQL here is small CRUD (change
+        # detection sync entries, user devices, skill profiles, auth sessions), while report
+        # calculation runs against CouchDB/SQS. Note pgjdbc *closes* the connection when this
+        # fires, so it must stay well above the slowest legitimate statement, including the
+        # schema update Hibernate runs at startup.
+        # A deployment can still override it with URL parameters on SPRING_DATASOURCE_URL.
+        socketTimeout: 30
   jpa:
     generate-ddl: true
     hibernate:

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
@@ -1,0 +1,88 @@
+package com.aamdigital.aambackendservice.common.storage.di
+
+import com.aamdigital.aambackendservice.common.storage.di.DatabaseSentryEventProcessor.Companion.SQL_EXCEPTION_LOGGER
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import io.sentry.protocol.Message
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DatabaseSentryEventProcessorTest {
+    private val processor = DatabaseSentryEventProcessor()
+
+    private fun sqlEvent(
+        message: String,
+        logger: String = SQL_EXCEPTION_LOGGER
+    ): SentryEvent =
+        SentryEvent().apply {
+            this.logger = logger
+            this.message = Message().apply { formatted = message }
+        }
+
+    @Test
+    fun `leaves events from other loggers untouched`() {
+        // Given
+        val event = sqlEvent(message = "some unrelated error", logger = "com.example.OtherLogger")
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result).isSameAs(event)
+        assertThat(result.fingerprints).isNull()
+    }
+
+    @Test
+    fun `groups pool timeouts that differ only in the interpolated wait and pool counts`() {
+        // Given - the two messages that HikariCP produced for the same fault in production
+        val shortWaitMessage =
+            "HikariPool-1 - Connection is not available, request timed out after 37386ms " +
+                "(total=7, active=0, idle=6, waiting=0)"
+        val longWaitMessage =
+            "HikariPool-1 - Connection is not available, request timed out after 692895ms " +
+                "(total=9, active=0, idle=9, waiting=0)"
+
+        val shortWait = sqlEvent(shortWaitMessage)
+        val longWait = sqlEvent(longWaitMessage)
+
+        // When
+        val shortWaitResult = processor.process(shortWait, Hint())
+        val longWaitResult = processor.process(longWait, Hint())
+
+        // Then
+        assertThat(shortWaitResult.fingerprints).isEqualTo(longWaitResult.fingerprints)
+        assertThat(shortWaitResult.fingerprints).containsExactly(
+            SQL_EXCEPTION_LOGGER,
+            "HikariPool-# - Connection is not available, request timed out after #ms " +
+                "(total=#, active=#, idle=#, waiting=#)"
+        )
+    }
+
+    @Test
+    fun `keeps genuinely different sql errors in separate groups`() {
+        // Given
+        val connectionClosed = sqlEvent("This connection has been closed.")
+        val constraintViolation = sqlEvent("ERROR: duplicate key value violates unique constraint")
+
+        // When
+        val connectionClosedResult = processor.process(connectionClosed, Hint())
+        val constraintViolationResult = processor.process(constraintViolation, Hint())
+
+        // Then
+        assertThat(connectionClosedResult.fingerprints)
+            .isNotEqualTo(constraintViolationResult.fingerprints)
+    }
+
+    @Test
+    fun `forwards the event unchanged when it carries no message`() {
+        // Given
+        val event = SentryEvent().apply { logger = SQL_EXCEPTION_LOGGER }
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result).isSameAs(event)
+        assertThat(result.fingerprints).isNull()
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatasourceTimeoutConfigurationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatasourceTimeoutConfigurationTest.kt
@@ -1,0 +1,62 @@
+package com.aamdigital.aambackendservice.common.storage.di
+
+import com.zaxxer.hikari.HikariConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources
+import org.springframework.boot.env.YamlPropertySourceLoader
+import org.springframework.core.env.MutablePropertySources
+import org.springframework.core.io.ClassPathResource
+
+/**
+ * Guards the datasource timeout settings in the shipped `application.yaml`.
+ *
+ * `socketTimeout` is passed straight through to the PostgreSQL driver, which makes it fragile in
+ * two ways that are invisible in review:
+ *
+ * 1. pgjdbc property names are case-sensitive. If relaxed binding ever lowercased the map key,
+ *    the driver would silently ignore `sockettimeout` and the timeout would be gone.
+ * 2. pgjdbc expresses it in **seconds**, while every neighbouring HikariCP setting is in
+ *    milliseconds. `30000` would look right and mean 8.3 hours.
+ *
+ * This binds the real configuration file the same way Spring Boot binds `spring.datasource.hikari`,
+ * so either mistake fails the build rather than shipping a timeout that never fires.
+ */
+class DatasourceTimeoutConfigurationTest {
+    private fun bindHikariConfig(): HikariConfig {
+        val baseDocument =
+            YamlPropertySourceLoader()
+                .load("application.yaml", ClassPathResource("application.yaml"))
+                .first() // the second document is the local-development profile
+
+        val propertySources = MutablePropertySources().apply { addFirst(baseDocument) }
+
+        return Binder(ConfigurationPropertySources.from(propertySources))
+            .bind("spring.datasource.hikari", HikariConfig::class.java)
+            .orElseThrow { AssertionError("no spring.datasource.hikari configuration found") }
+    }
+
+    @Test
+    fun `passes socketTimeout to the driver with its case and seconds unit intact`() {
+        // Given / When
+        val socketTimeout = bindHikariConfig().dataSourceProperties.getProperty("socketTimeout")
+
+        // Then - seconds, not milliseconds
+        assertThat(socketTimeout).isEqualTo("30")
+    }
+
+    @Test
+    fun `relies on HikariCP defaults for every timeout that is already bounded`() {
+        // Given / When
+        val hikariConfig = bindHikariConfig()
+
+        // Then - these are deliberately not configured; asserting the defaults documents why, and
+        // catches a dependency upgrade that changes them (keepaliveTime moved from disabled to
+        // 2 minutes in HikariCP 6.3, which is what made the original report look actionable).
+        assertThat(hikariConfig.keepaliveTime).isEqualTo(120_000)
+        assertThat(hikariConfig.maxLifetime).isEqualTo(1_800_000)
+        assertThat(hikariConfig.connectionTimeout).isEqualTo(30_000)
+        assertThat(hikariConfig.validationTimeout).isEqualTo(5_000)
+    }
+}


### PR DESCRIPTION
Addresses the actionable half of Aam-Digital/aam-services#163.

## What the investigation found

The issue proposed an explicit HikariCP block with `keepalive-time`, `max-lifetime`,
`validation-timeout` and `connection-timeout`, plus `socketTimeout`, `connectTimeout` and
`tcpKeepAlive` on the JDBC URL. Checked against the versions this build actually resolves
(HikariCP 6.3.3, pgjdbc 42.7.13), **six of those seven are already at the proposed value or a
sane default**:

| Setting | Proposed | Current effective value |
|---|---|---|
| `keepalive-time` | 120000 | **120000** — `DEFAULT_KEEPALIVE_TIME` in HikariCP 6.3 |
| `max-lifetime` | 1800000 | 1800000 (default) |
| `validation-timeout` | 5000 | 5000 (default) |
| `connection-timeout` | 30000 | 30000 (default) |
| `connectTimeout` | 10 | 10 (pgjdbc default) |
| `tcpKeepAlive` | true | false — inert anyway without OS tuning (`tcp_keepalive_time` is 7200s) |
| **`socketTimeout`** | 30 | **0 = disabled** |

So the premise that "keepalive is disabled entirely" no longer holds — HikariCP enabled it by
default in 6.3, and it was already running throughout the reported incidents. Only `socketTimeout`
is a real gap.

## 1. `socketTimeout`

It is the one path whose failure produces *no signal*: every other timeout fails fast and loudly and
is retried by `ScheduledJobBackoff`, whereas an unbounded socket read leaves the scheduled poller
stalled until the OS stops retransmitting (~15 min on Linux).

Set in `application.yaml`, not on `SPRING_DATASOURCE_URL`, so it ships in the image and reaches
deployments that supply their own JDBC URL. HikariCP's `DriverDataSource` forwards
`data-source-properties` into `Driver.connect`, and pgjdbc's `parseURL` still lets URL parameters
override it, so per-deployment tuning is preserved.

⚠️ The value is in **seconds** — unlike every millisecond-based HikariCP setting next to it. 30s is a
wide margin: everything in PostgreSQL here is small CRUD (change-detection sync entries, user
devices, skill profiles, auth sessions), while report calculation runs against CouchDB/SQS. pgjdbc
*closes* the connection when this fires, so the margin is deliberate.

`DatasourceTimeoutConfigurationTest` binds the real `application.yaml` and guards the two mistakes
that would silently disable this — relaxed binding lowercasing the case-sensitive pgjdbc key, and
the value being written in milliseconds. It also asserts the four defaults above, so a dependency
upgrade that changes them fails the build instead of going unnoticed, which is exactly how the
original report went stale.

## 2. Sentry grouping

`ScheduledJobBackoff` already catches, backs off and retries these failures and logs at WARN — but
Hibernate's `SqlExceptionHelper` logs the same failure at ERROR *before* it propagates, which is
what reaches Sentry. This is the same shape `QueueErrorHandler` documents for the AMQP path.

Because HikariCP interpolates the elapsed wait and pool counts into its message, every occurrence
looked unique and one fault kept spawning fresh Sentry issues. That is not only noise:
`archived_until_escalating` evaluates event counts *per issue*, so events bleeding into new issues
suppress the escalation that would surface the fault again.

`DatabaseSentryEventProcessor` replaces digit runs when building the fingerprint, so interpolated
variants collapse into one issue while genuinely different SQL errors stay apart. Follows the
existing `QueueSentryEventProcessor` precedent.

Note the custom fingerprint produces a new grouping hash, so future events land in a **new**,
unarchived issue rather than merging into the currently-archived one. That sidesteps the sequencing
concern raised on the issue; the old issues can simply be resolved once events stop arriving.

## What this does *not* fix

`socketTimeout` bounds socket **reads**. It does not bound writes — `SO_TIMEOUT` never has — so if
the multi-minute stalls came from a blocked write, this would not have changed the outcome. Those
are bounded by `tcp_retries2` / `TCP_USER_TIMEOUT` at the deployment level, not by any JDBC setting.
The remaining waits are also consistent with a host-level stall, which is infrastructure. See Aam-Digital/internal#359.

Worth noting the reported waits are two populations, not one: a single `getConnection()` with these
defaults can legitimately reach ≈35s (30s cap, plus a final 5s validation that starts just under
it), so the observed 37s and 40s are a correctly-working pool giving up. Only 64s and above need a
mechanism.

## Testing

- 301 unit tests pass, 0 failures (295 before, 6 added).
- New files are ktlint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved database error tracking by grouping similar SQL and connection-pool failures more consistently.
  * Added a 30-second PostgreSQL connection timeout to help prevent stalled database operations from waiting indefinitely.
  * Preserved distinct error details while normalizing variable values for clearer monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->