### PR TITLE
fix(aam-backend-service): tag Sentry events with a release version

### DIFF
--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -86,6 +86,17 @@ jobs:
         if: ${{ github.event.ref  == '' }}
         run: echo "TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
 
+      - name: Determine application version
+        # Baked into the image as sentry.release (see application.yaml) so error events are
+        # tagged with a version. Tag pushes get the released version; everything else (main,
+        # PRs) gets the commit SHA, since TAG above is not unique per build in those cases.
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/aam-backend-service/* ]]; then
+            echo "APPLICATION_VERSION=${GITHUB_REF#refs/tags/aam-backend-service/}" >> $GITHUB_ENV
+          else
+            echo "APPLICATION_VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
       - name: Prepare Platform
         run: |
           platform=${{ matrix.platform }}
@@ -127,6 +138,8 @@ jobs:
           context: ./application/aam-backend-service
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APPLICATION_VERSION=${{ env.APPLICATION_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}
           cache-to: type=gha,mode=min,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}

--- a/application/aam-backend-service/Dockerfile
+++ b/application/aam-backend-service/Dockerfile
@@ -10,5 +10,10 @@ RUN gradle installDist
 FROM amazoncorretto:21.0.12-alpine
 WORKDIR /opt/app
 COPY --from=BUILD /opt/app/build/install/aam-backend-service /opt/app
+# Consumed at runtime as sentry.release (see application.yaml) so error events are tagged with a
+# version. Left empty rather than a placeholder like "unknown" when not passed at build time, so
+# Sentry falls back to no release instead of lumping unrelated builds under one fake release.
+ARG APPLICATION_VERSION=
+ENV APPLICATION_VERSION=${APPLICATION_VERSION}
 EXPOSE 8080
 CMD ./bin/aam-backend-service

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -238,6 +238,7 @@ crypto-configuration:
 sentry:
   logging:
     enabled: false
+  release: ${APPLICATION_VERSION:}
 
 application:
   base-url: https://aam.localhost

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -238,7 +238,7 @@ crypto-configuration:
 sentry:
   logging:
     enabled: false
-  release: ${APPLICATION_VERSION:}
+  release: ${APPLICATION_VERSION:#{null}}
 
 application:
   base-url: https://aam.localhost


### PR DESCRIPTION
## Summary

`aam-backend-service` has never had any Sentry releases — the `sentry {}` block in `build.gradle.kts` reads `APPLICATION_VERSION`/`SENTRY_AUTH_TOKEN` from the environment, but neither is ever set: not in this workflow, and not forwarded into the Docker build (no `ARG`, no `build-args`). That release-creation path also requires an auth token that isn't configured anywhere, so it silently no-ops — confirmed by running the build locally with a version set and observing no release/version artifact is produced for the runtime SDK to pick up.

This PR wires up a separate, simpler path that doesn't need any new secret:

- **CI**: derive `APPLICATION_VERSION` per build — the released tag on a version-tag push, the commit SHA otherwise (unique per build, unlike the branch push case previously).
- **Dockerfile**: accept it as a build-arg and bake it into the image as a runtime env var (empty default, not a placeholder like `unknown`, so an unset build still means "no release" rather than a made-up bucket every unrelated build gets lumped into).
- **application.yaml**: `sentry.release: ${APPLICATION_VERSION:}` — confirmed `sentry-spring-boot-jakarta` is on the runtime classpath, so this autoconfiguration property is actually read.

Local dev is unaffected — `docs/developer/docker-compose.yml` pulls a prebuilt image rather than building locally, and the baked-in env var passes through untouched.

**Not in scope**: proper Sentry release objects with commit association and source-context upload for readable stack traces both go through the Gradle plugin's authenticated path, which still needs a `SENTRY_AUTH_TOKEN` repo secret to be added before it does anything.

## Test plan

- [x] `./gradlew installDist` with `APPLICATION_VERSION` set and no auth token — builds successfully, confirms the Gradle-plugin path is a safe no-op
- [x] `docker build --build-arg APPLICATION_VERSION=v1.2.3 ...` then `docker run ... echo $APPLICATION_VERSION` — prints `v1.2.3`
- [x] `docker build` without the build-arg — env var is empty, not a placeholder
- [ ] After merge: confirm a subsequent deploy's Sentry events carry a `release` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application version tracking for builds, using release tags or commit identifiers.
  * Build versions are now available at runtime to improve release identification.

* **Bug Fixes**
  * Improved error-monitoring release association, making it easier to correlate reported issues with the deployed application version.

* **Chores**
  * Added support for configuring application versions during container image builds.
  * Local development continues to work without requiring a version value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->