### PR TITLE
chore(renovate): fix invalid vulnerabilityAlerts option and align the update window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     ],
     "timezone": "Etc/UTC",
     "schedule": [
-        "after 00:00 and before 04:00 on Wednesday"
+        "* * * * 3"
     ],
     "dependencyDashboard": false,
     "prConcurrentLimit": 5,
@@ -34,8 +34,7 @@
         "labels": [
             "dependencies",
             "security"
-        ],
-        "prPriority": 10
+        ]
     },
     "osvVulnerabilityAlerts": true,
     "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     ],
     "timezone": "Etc/UTC",
     "schedule": [
-        "* * * * 3"
+        "* * * * 0"
     ],
     "dependencyDashboard": false,
     "prConcurrentLimit": 5,


### PR DESCRIPTION
Part of a sweep across all six Aam Digital repos to make sure every dependency surface is actually watched by Renovate.

Manager coverage here is already complete — gradle, maven, github-actions, dockerfile, docker-compose and the two custom regex managers together extract 83 deps across 14 files. Two things were still wrong.

## 1. A config warning on every run

```
"prPriority" can't be used in "vulnerabilityAlerts". Allowed objects: packageRules.
```

The option is only valid inside `packageRules`, so it was silently doing nothing. Removed.

## 2. This repo has never had a Renovate PR

Not one, despite the config having been in place since at least March. There is plenty pending — a dry-run right now would open `carbone`, `keycloak`, `jvm-toolchain`, `weekly-non-major-updates`, `major-jvm-toolchain`, `major-spring-boot`, `postgres-18.x` and `conventional_commits_next_version-7.x`. (Dependabot has been filling the gap: #168.)

The most likely cause is the `schedule`: PR creation only happens if a hosted-app run lands inside the window, and a **4-hour window once a week** (Wed 00:00–04:00) is easy to miss entirely. As part of aligning all six repos on one window, this moves to **all day Sunday** (`* * * * 0`) — 24 hours to land instead of 4, and the same day as every other repo. `vulnerabilityAlerts` still runs at any time.

If PRs still don't appear after this merges, the next place to look is the Mend dashboard (app.mend.io), where repos can be deactivated independently of the GitHub App installation.

## Verified

Config passes `renovate-config-validator --strict`, and a dry-run against this branch no longer reports the config warning.
