### PR TITLE
docs(export-api): document the optional `complement` field of render requests

### DIFF
--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
@@ -218,6 +218,37 @@ class DefaultRenderTemplateBatchUseCaseTest : WebClientTestBase() {
     }
 
     @Test
+    fun `should forward additional request body fields like complement to carbone unchanged`() {
+        val templateRef = DomainReference("some-id")
+        val bodyData: JsonNode =
+            objectMapper.readValue(
+                """
+                {"convertTo":"pdf","data":[{"name":"Alice"},{"name":"Bob"}],
+                "complement":{"user":{"name":"Grace Hopper"}}}
+                """.trimIndent()
+            )
+        whenever(templateStorage.fetchTemplate(templateRef)).thenReturn(template())
+        enqueueRenderAndFile(renderId = "render-zip-1", contentType = "application/zip")
+
+        val response =
+            service.run(
+                RenderTemplateBatchRequest(
+                    templateRef = templateRef,
+                    bodyData = bodyData,
+                    mode = RenderTemplateBatchMode.ZIP
+                )
+            )
+
+        assertThat(response).isInstanceOf(UseCaseOutcome.Success::class.java)
+        val renderRequest = mockWebServer.takeRequest()
+        val sentBody: Map<String, Any?> = objectMapper.readValue(renderRequest.body.readUtf8())
+        // the complement is sent once for the whole batch, next to the split-up data array
+        assertThat(sentBody["complement"])
+            .isEqualTo(mapOf("user" to mapOf("name" to "Grace Hopper")))
+        assertThat(sentBody["data"]).isInstanceOf(List::class.java)
+    }
+
+    @Test
     fun `ZIP mode should sanitize illegal filesystem characters from the target file name pattern`() {
         val templateRef = DomainReference("some-id")
         val bodyData: JsonNode =

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateUseCaseTest.kt
@@ -292,6 +292,65 @@ class DefaultRenderTemplateUseCaseTest : WebClientTestBase() {
     }
 
     @Test
+    fun `should forward additional request body fields like complement to carbone unchanged`() {
+        // given
+        val templateRef = DomainReference("some-id")
+        val bodyData: JsonNode =
+            objectMapper.readValue(
+                """
+                {"convertTo":"pdf","data":{"name":"Ada"},"complement":{"user":{"name":"Grace Hopper"}}}
+                """.trimIndent()
+            )
+        val templateExport =
+            TemplateExport(
+                id = "export-id",
+                templateId = "export-template-id",
+                targetFileName = "target_file_name.pdf",
+                title = "export-title",
+                description = "export-description",
+                applicableForEntityTypes = emptyList()
+            )
+
+        whenever(templateStorage.fetchTemplate(templateRef)).thenReturn(templateExport)
+
+        mockWebServer.enqueue(
+            MockResponse().setBody(
+                """{"success":true,"data":{"renderId":"some-render-id"}}"""
+            )
+        )
+
+        val buffer = Buffer()
+        buffer.writeAll(File("src/test/resources/files/pdf-test-file-1.pdf").source())
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setHeaders(
+                    mapOf(
+                        "Content-Type" to "application/pdf",
+                        "Content-Length" to buffer.size.toString()
+                    ).toHeaders()
+                ).setBody(buffer)
+        )
+
+        // when
+        val response =
+            service.run(
+                RenderTemplateRequest(
+                    templateRef,
+                    bodyData
+                )
+            )
+
+        // then
+        assertThat(response).isInstanceOf(UseCaseOutcome.Success::class.java)
+        val renderRequest = mockWebServer.takeRequest()
+        val sentBody: Map<String, Any?> = objectMapper.readValue(renderRequest.body.readUtf8())
+        assertThat(sentBody["data"]).isEqualTo(mapOf("name" to "Ada"))
+        assertThat(sentBody["complement"])
+            .isEqualTo(mapOf("user" to mapOf("name" to "Grace Hopper")))
+    }
+
+    @Test
     fun `should return Failure with parsed error message`() {
         // given
         val templateRef = DomainReference("some-id")

--- a/docs/api-specs/export-api-v1.yaml
+++ b/docs/api-specs/export-api-v1.yaml
@@ -267,6 +267,14 @@ components:
           type: object
           additionalProperties: true
           description: Placeholder values injected into the template.
+        complement:
+          type: object
+          additionalProperties: true
+          description: >-
+            Optional context data available in the template (and in `reportName`) under
+            carbone's `{c.…}` prefix, separate from the record data under `{d.…}`.
+            Used by the Aam Digital app to expose the logged-in user's record as
+            `{c.user.…}`.
         reportName:
           type: string
           description: Optional output file name (supports carbone placeholders).
@@ -286,6 +294,15 @@ components:
           type: string
           description: The per-document output format, e.g. "pdf".
           example: pdf
+        complement:
+          type: object
+          additionalProperties: true
+          description: >-
+            Optional context data available in the template (and in `reportName` /
+            `batchReportName`) under carbone's `{c.…}` prefix, separate from the record
+            data under `{d.…}`. It is sent once and shared by every record of the batch.
+            Used by the Aam Digital app to expose the logged-in user's record as
+            `{c.user.…}`.
         reportName:
           type: string
           description: Optional output file name (supports carbone placeholders).
@@ -296,6 +313,9 @@ components:
           - firstname: Alan
             lastname: Turing
         convertTo: pdf
+        complement:
+          user:
+            name: Grace Hopper
         reportName: "report-{d.lastname}.pdf"
     Error:
       type: object


### PR DESCRIPTION
Supports Aam-Digital/ndb-core#4233 / Aam-Digital/ndb-core#4287.

The export controller takes the raw request body and forwards it to carbone, so a client can already pass carbone's `complement` option to make additional context data available in templates under the `{c.…}` prefix — separate from the record data under `{d.…}`.

The Aam Digital app now uses this to expose the logged-in user's record as `{c.user.…}` (e.g. `{c.user.name}`), so a generated document can pre-fill the name of the person signing it.

**No production code change** — the passthrough already works. This PR only:

- documents `complement` on the `RenderRequest` / `RenderBatchRequest` schemas in `export-api-v1.yaml`, including an example
- adds a test on both the single and the batch render use case asserting that unknown body fields are forwarded to carbone verbatim

The second point is the actual value here: the passthrough was an implicit, undocumented contract that nothing pinned down, so it could have been broken by an innocent refactoring of the request handling. The batch test also pins the behaviour that the complement is sent **once** for the whole batch, next to the split-up `data` array.

### Testing

`DefaultRenderTemplateUseCaseTest` (9/9) and `DefaultRenderTemplateBatchUseCaseTest` (11/11) pass locally, including the two new cases.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)