### PR TITLE
fix(export): fill the current-date placeholder in batch renders

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCase.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCase.kt
@@ -16,6 +16,7 @@ import org.springframework.web.client.RestClient
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
+import java.time.Instant
 import java.util.Base64
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -37,7 +38,7 @@ import java.util.zip.ZipOutputStream
  */
 class DefaultRenderTemplateBatchUseCase(
     renderClient: RestClient,
-    objectMapper: ObjectMapper,
+    private val objectMapper: ObjectMapper,
     templateStorage: TemplateStorage,
 ) : RenderTemplateBatchUseCase() {
     private val carboneClient =
@@ -93,6 +94,7 @@ class DefaultRenderTemplateBatchUseCase(
             // Carbone v5+ substitutes {d.field} placeholders per record for each zip entry name
             bodyData.put("batchReportName", targetFileName)
         }
+        provideCurrentDate(bodyData)
 
         val raw = carboneClient.createRenderRequest(template.templateId, bodyData)
         val renderId = carboneClient.parseRenderId(raw)
@@ -111,6 +113,30 @@ class DefaultRenderTemplateBatchUseCase(
                     responseHeaders = result.headers,
                 ),
         )
+    }
+
+    /**
+     * Provide the value behind Carbone's reserved `{c.now}` placeholder.
+     *
+     * Carbone fills that placeholder itself, but only for single renders. With `batchSplitBy` set
+     * it stays empty, so templates using `{c.now}` would render a blank date in bulk exports.
+     * Passing the date explicitly is the documented override and keeps both modes consistent,
+     * with the whole batch sharing one timestamp.
+     *
+     * A caller-provided `now` wins, matching Carbone's own precedence.
+     */
+    private fun provideCurrentDate(bodyData: ObjectNode) {
+        val existing = bodyData.get("complement")
+        if (existing != null && existing !is ObjectNode) {
+            // unexpected shape: leave it untouched rather than discarding caller data
+            return
+        }
+
+        val complement = existing as? ObjectNode ?: objectMapper.createObjectNode()
+        if (!complement.has("now")) {
+            complement.put("now", Instant.now().toString())
+        }
+        bodyData.replace("complement", complement)
     }
 
     private fun carboneBatchOutput(mode: RenderTemplateBatchMode): String =

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.whenever
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.time.Instant
 import java.util.Base64
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
@@ -215,6 +216,57 @@ class DefaultRenderTemplateBatchUseCaseTest : WebClientTestBase() {
         assertThat(sentBody["reportName"]).isEqualTo("test_letter_{d.name}.pdf")
         assertThat(sentBody["batchReportName"]).isEqualTo("test_letter_{d.name}.pdf")
         assertThat(sentBody["data"]).isInstanceOf(List::class.java)
+    }
+
+    @Test
+    fun `should add the current date to the complement so Carbone fills its reserved now keyword`() {
+        val templateRef = DomainReference("some-id")
+        val bodyData: JsonNode =
+            objectMapper.readValue("""{"convertTo":"pdf","data":[{"name":"Alice"},{"name":"Bob"}]}""")
+        whenever(templateStorage.fetchTemplate(templateRef)).thenReturn(template())
+        enqueueRenderAndFile(renderId = "render-zip-1", contentType = "application/zip")
+
+        service.run(
+            RenderTemplateBatchRequest(
+                templateRef = templateRef,
+                bodyData = bodyData,
+                mode = RenderTemplateBatchMode.ZIP
+            )
+        )
+
+        val renderRequest = mockWebServer.takeRequest()
+        val sentBody: Map<String, Any?> = objectMapper.readValue(renderRequest.body.readUtf8())
+
+        @Suppress("UNCHECKED_CAST")
+        val complement = sentBody["complement"] as Map<String, Any?>
+        assertThat(Instant.parse(complement["now"] as String)).isNotNull()
+    }
+
+    @Test
+    fun `should keep a caller-provided complement including an explicit now`() {
+        val templateRef = DomainReference("some-id")
+        val bodyData: JsonNode =
+            objectMapper.readValue(
+                """{"data":[{"name":"Alice"}],"complement":{"now":"2020-01-01T00:00:00Z","user":{"name":"Bob"}}}"""
+            )
+        whenever(templateStorage.fetchTemplate(templateRef)).thenReturn(template())
+        enqueueRenderAndFile(renderId = "render-zip-1", contentType = "application/zip")
+
+        service.run(
+            RenderTemplateBatchRequest(
+                templateRef = templateRef,
+                bodyData = bodyData,
+                mode = RenderTemplateBatchMode.ZIP
+            )
+        )
+
+        val renderRequest = mockWebServer.takeRequest()
+        val sentBody: Map<String, Any?> = objectMapper.readValue(renderRequest.body.readUtf8())
+
+        @Suppress("UNCHECKED_CAST")
+        val complement = sentBody["complement"] as Map<String, Any?>
+        assertThat(complement["now"]).isEqualTo("2020-01-01T00:00:00Z")
+        assertThat(complement["user"]).isEqualTo(mapOf("name" to "Bob"))
     }
 
     @Test

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/usecase/DefaultRenderTemplateBatchUseCaseTest.kt
@@ -411,6 +411,11 @@ class DefaultRenderTemplateBatchUseCaseTest : WebClientTestBase() {
         assertThat(sentBody["batchSplitBy"]).isEqualTo("d")
         assertThat(sentBody["batchOutput"]).isEqualTo("pdf")
         assertThat(sentBody).doesNotContainKey("batchReportName")
+
+        // the blank {c.now} affected both batch modes, so guard the date here as well
+        @Suppress("UNCHECKED_CAST")
+        val complement = sentBody["complement"] as Map<String, Any?>
+        assertThat(Instant.parse(complement["now"] as String)).isNotNull()
     }
 
     @Test

--- a/docs/modules/export.md
+++ b/docs/modules/export.md
@@ -72,18 +72,6 @@ If this value is missing or `0`, Carbone returns:
 For local development with `docs/developer/docker-compose.yml`, this repository provides
 `docs/developer/carbone.config.json`, mounted to `/app/config/config.json` for the `carbone-io` service.
 
-#### The `{c.now}` placeholder in batch mode
-
-Carbone resolves its reserved `{c.now}` placeholder (see
-[Carbone date formatters](https://carbone.io/documentation/design/formatters/date.html#current-date))
-by injecting the current date itself, but only for single renders. With `batchSplitBy` set it stays empty,
-so a template that prints the generation date would render a blank value in bulk exports while working fine
-for a single record.
-
-The bulk use case therefore passes the date explicitly as `complement.now`, which is the documented way to
-override the value. All records of one batch share the same timestamp. A `complement.now` supplied by the
-caller keeps precedence.
-
 ### OAuth Proxy & Keycloak Client
 In our standard hosted setup, the carbone.io server is protected by an OAUTH proxy.
 The Keycloak Client used by our backend to authenticate against this can be reused across different systems.

--- a/docs/modules/export.md
+++ b/docs/modules/export.md
@@ -72,6 +72,18 @@ If this value is missing or `0`, Carbone returns:
 For local development with `docs/developer/docker-compose.yml`, this repository provides
 `docs/developer/carbone.config.json`, mounted to `/app/config/config.json` for the `carbone-io` service.
 
+#### The `{c.now}` placeholder in batch mode
+
+Carbone resolves its reserved `{c.now}` placeholder (see
+[Carbone date formatters](https://carbone.io/documentation/design/formatters/date.html#current-date))
+by injecting the current date itself, but only for single renders. With `batchSplitBy` set it stays empty,
+so a template that prints the generation date would render a blank value in bulk exports while working fine
+for a single record.
+
+The bulk use case therefore passes the date explicitly as `complement.now`, which is the documented way to
+override the value. All records of one batch share the same timestamp. A `complement.now` supplied by the
+caller keeps precedence.
+
 ### OAuth Proxy & Keycloak Client
 In our standard hosted setup, the carbone.io server is protected by an OAUTH proxy.
 The Keycloak Client used by our backend to authenticate against this can be reused across different systems.


### PR DESCRIPTION
Fixes #185

## Manual Testing Steps

Needs a running Export API with a Carbone instance that has batch enabled (`nbReportMaxPerBatch` greater than 0, see `docs/modules/export.md`).

1. In the app, open the template configuration and upload a template that contains a date placeholder written as `{c.now:formatD(DD.MM.YYYY)}`, applicable for an entity type that has a list view.
2. Open a single record of that type and use "Generate File" with this template. The generated file shows today's date. This is the behaviour that already worked, confirming the template is correct.
3. Go to the list of that entity type, tick **two or more** records, and run the "Generate File" bulk action with the same template.
4. Open the files in the downloaded ZIP. Each one shows today's date in the same place. Before this change the date was blank here.
5. Repeat step 3 with the "combine into a single PDF" option enabled. Every page shows today's date.
6. Confirm the date is identical across all records of one bulk run.

## Notes for a follow-up, not part of this PR

Neither flow sends Carbone's `timezone` option, so `formatD` falls back to Carbone's `Europe/Paris` default. For a user in Asia/Kolkata at 02:00 local time, `{c.now:formatD(DD.MM.YYYY)}` prints the previous day. That off-by-one already exists for single renders today and is unchanged here. Happy to file it separately if it is worth fixing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch-generated ZIP documents now include the current timestamp for template fields using the reserved “now” value.
  * Existing caller-provided timestamp and complement data are preserved.
  * Missing complement data is handled automatically during rendering.
  * Combined batch rendering now consistently provides the current timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->