### PR TITLE
fix: stop writing streamed downloads from an async task

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/controller/TemplateExportController.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/export/controller/TemplateExportController.kt
@@ -21,6 +21,7 @@ import com.aamdigital.aambackendservice.export.core.RenderTemplateUseCase
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
+import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -35,8 +36,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
-import java.io.OutputStream
 
 sealed interface TemplateExportControllerResponse {
     /**
@@ -45,27 +44,6 @@ sealed interface TemplateExportControllerResponse {
     data class CreateTemplateControllerResponse(
         val templateId: String
     ) : TemplateExportControllerResponse
-
-    /**
-     * StreamingResponse of the template binary file
-     */
-    fun interface FetchTemplateControllerResponse :
-        StreamingResponseBody,
-        TemplateExportControllerResponse
-
-    /**
-     * StreamingResponse of the template, rendered with passed data as binary file
-     */
-    fun interface RenderTemplateControllerResponse :
-        StreamingResponseBody,
-        TemplateExportControllerResponse
-
-    /**
-     * StreamingResponse of a bulk render (ZIP archive of N files, or a single combined file).
-     */
-    fun interface RenderTemplateBatchControllerResponse :
-        StreamingResponseBody,
-        TemplateExportControllerResponse
 
     class ErrorControllerResponse(
         errorCode: String,
@@ -83,6 +61,22 @@ sealed interface TemplateExportControllerResponse {
  *
  * In Aam, this API is especially used for generating PDFs for an entity.
  *
+ * Every endpoint that answers with a file returns an [InputStreamResource] rather than a
+ * `org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody`. A
+ * StreamingResponseBody is written from an async task while the container owns the request
+ * lifecycle, so Tomcat can recycle the request underneath the writer - on the async timeout (30s
+ * by default, which by itself truncates slow downloads) or when the client goes away. Both threads
+ * then touch the same `MimeHeaders`, which is not thread safe, and the response commit fails with
+ * a NullPointerException from inside Tomcat, sometimes taking whichever request next reuses the
+ * recycled objects with it. Neither Tomcat nor Spring treats that as fixable on their side
+ * (spring-framework#33439 was closed as not planned).
+ *
+ * Returning a Resource keeps the copy on the request thread, where the container cannot recycle
+ * anything until the handler returns. Virtual threads are enabled, so blocking that thread for the
+ * length of a download is cheap, and a client that disappears mid-download surfaces as a
+ * `ClientAbortException` that Spring's `DefaultHandlerExceptionResolver` logs at DEBUG.
+ * `ResourceHttpMessageConverter` copies the stream verbatim and closes it afterwards.
+ *
  * @param createTemplateUseCase Use case for creating a new template.
  * @param fetchTemplateUseCase Use case for fetching an existing template (file).
  * @param renderTemplateUseCase Use case for rendering an existing template.
@@ -98,10 +92,6 @@ class TemplateExportController(
     private val renderTemplateBatchUseCase: RenderTemplateBatchUseCase,
     private val objectMapper: ObjectMapper
 ) {
-    companion object {
-        private const val BYTE_ARRAY_BUFFER_LENGTH = 4096
-    }
-
     private val logger = LoggerFactory.getLogger(javaClass)
 
     private fun getErrorEntity(
@@ -119,26 +109,26 @@ class TemplateExportController(
             )
 
     /*
-     * Needed so be able to return "ResponseEntity<StreamingResponseBody>" without the need to write a converter.
+     * Keeps the error responses the same body type as the success ones, so no converter is needed.
      */
-    private fun getErrorStreamingBody(result: Failure<*>) =
-        StreamingResponseBody { outputStream: OutputStream ->
-            val buffer = ByteArray(BYTE_ARRAY_BUFFER_LENGTH)
-            var bytesRead: Int
+    private fun getErrorBody(result: Failure<*>) =
+        getErrorBody(
+            errorCode = result.errorCode.toString(),
+            errorMessage = result.errorMessage
+        )
 
-            val bodyStream =
-                objectMapper
-                    .writeValueAsString(
-                        TemplateExportControllerResponse.ErrorControllerResponse(
-                            errorCode = result.errorCode.toString(),
-                            errorMessage = result.errorMessage
-                        )
-                    ).byteInputStream()
-
-            while ((bodyStream.read(buffer).also { bytesRead = it }) != -1) {
-                outputStream.write(buffer, 0, bytesRead)
-            }
-        }
+    private fun getErrorBody(
+        errorCode: String,
+        errorMessage: String
+    ) = InputStreamResource(
+        objectMapper
+            .writeValueAsString(
+                TemplateExportControllerResponse.ErrorControllerResponse(
+                    errorCode = errorCode,
+                    errorMessage = errorMessage
+                )
+            ).byteInputStream()
+    )
 
     @PostMapping("/template")
     fun postTemplate(
@@ -192,7 +182,7 @@ class TemplateExportController(
     @GetMapping("/template/{templateId}")
     fun fetchTemplate(
         @PathVariable templateId: String
-    ): ResponseEntity<StreamingResponseBody> {
+    ): ResponseEntity<InputStreamResource> {
         val result =
             fetchTemplateUseCase.run(
                 FetchTemplateRequest(
@@ -202,22 +192,10 @@ class TemplateExportController(
 
         return when (result) {
             is Success -> {
-                val responseBody =
-                    TemplateExportControllerResponse.FetchTemplateControllerResponse { outputStream: OutputStream ->
-                        val buffer = ByteArray(BYTE_ARRAY_BUFFER_LENGTH)
-                        var bytesRead: Int
-                        while ((
-                                result.data.file
-                                    .read(buffer)
-                                    .also { bytesRead = it }
-                            ) != -1
-                        ) {
-                            outputStream.write(buffer, 0, bytesRead)
-                        }
-                    }
+                val responseBody = InputStreamResource(result.data.file)
 
                 logger.trace(
-                    "[TemplateExportController.fetchTemplate()] success response: (FetchTemplateControllerResponse)"
+                    "[TemplateExportController.fetchTemplate()] success response: (template file)"
                 )
 
                 ResponseEntity(
@@ -228,7 +206,7 @@ class TemplateExportController(
             }
 
             is Failure -> {
-                val errorStreamingBody = getErrorStreamingBody(result)
+                val errorBody = getErrorBody(result)
                 val headers = HttpHeaders()
                 headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 
@@ -236,14 +214,14 @@ class TemplateExportController(
                     when (result.errorCode as FetchTemplateError) {
                         FetchTemplateError.NOT_FOUND_ERROR ->
                             ResponseEntity(
-                                errorStreamingBody,
+                                errorBody,
                                 headers,
                                 HttpStatus.NOT_FOUND
                             )
 
                         else ->
                             ResponseEntity(
-                                errorStreamingBody,
+                                errorBody,
                                 headers,
                                 HttpStatus.INTERNAL_SERVER_ERROR
                             )
@@ -258,7 +236,7 @@ class TemplateExportController(
     fun renderTemplate(
         @PathVariable templateId: String,
         @RequestBody templateData: JsonNode
-    ): ResponseEntity<StreamingResponseBody> {
+    ): ResponseEntity<InputStreamResource> {
         val result =
             renderTemplateUseCase.run(
                 RenderTemplateRequest(
@@ -269,22 +247,10 @@ class TemplateExportController(
 
         return when (result) {
             is Success -> {
-                val responseBody =
-                    TemplateExportControllerResponse.RenderTemplateControllerResponse { outputStream: OutputStream ->
-                        val buffer = ByteArray(BYTE_ARRAY_BUFFER_LENGTH)
-                        var bytesRead: Int
-                        while ((
-                                result.data.file
-                                    .read(buffer)
-                                    .also { bytesRead = it }
-                            ) != -1
-                        ) {
-                            outputStream.write(buffer, 0, bytesRead)
-                        }
-                    }
+                val responseBody = InputStreamResource(result.data.file)
 
                 logger.trace(
-                    "[TemplateExportController.renderTemplate()] success response: (RenderTemplateControllerResponse)"
+                    "[TemplateExportController.renderTemplate()] success response: (rendered file)"
                 )
 
                 ResponseEntity(
@@ -295,7 +261,7 @@ class TemplateExportController(
             }
 
             is Failure -> {
-                val errorStreamingBody = getErrorStreamingBody(result)
+                val errorBody = getErrorBody(result)
                 val headers = HttpHeaders()
                 headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 
@@ -303,14 +269,14 @@ class TemplateExportController(
                     when (result.errorCode as RenderTemplateError) {
                         RenderTemplateError.NOT_FOUND_ERROR ->
                             ResponseEntity(
-                                errorStreamingBody,
+                                errorBody,
                                 headers,
                                 HttpStatus.NOT_FOUND
                             )
 
                         else ->
                             ResponseEntity(
-                                errorStreamingBody,
+                                errorBody,
                                 headers,
                                 HttpStatus.INTERNAL_SERVER_ERROR
                             )
@@ -331,7 +297,7 @@ class TemplateExportController(
         @PathVariable templateId: String,
         @RequestParam(name = "mode", required = false, defaultValue = "zip") mode: String,
         @RequestBody templateData: JsonNode
-    ): ResponseEntity<StreamingResponseBody> {
+    ): ResponseEntity<InputStreamResource> {
         val parsedMode =
             when (mode.lowercase()) {
                 "zip" -> {
@@ -346,18 +312,10 @@ class TemplateExportController(
                     val headers = HttpHeaders()
                     headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     return ResponseEntity(
-                        StreamingResponseBody { outputStream: OutputStream ->
-                            outputStream.write(
-                                objectMapper
-                                    .writeValueAsString(
-                                        TemplateExportControllerResponse.ErrorControllerResponse(
-                                            errorCode = "INVALID_MODE",
-                                            errorMessage =
-                                                "Unsupported mode '$mode'. Allowed values: zip, combined."
-                                        )
-                                    ).toByteArray()
-                            )
-                        },
+                        getErrorBody(
+                            errorCode = "INVALID_MODE",
+                            errorMessage = "Unsupported mode '$mode'. Allowed values: zip, combined."
+                        ),
                         headers,
                         HttpStatus.BAD_REQUEST
                     )
@@ -377,14 +335,10 @@ class TemplateExportController(
             is Success -> {
                 val responseHeaders = HttpHeaders().apply { putAll(result.data.responseHeaders) }
 
-                val responseBody =
-                    TemplateExportControllerResponse.RenderTemplateBatchControllerResponse {
-                        result.data.file.copyTo(it, BYTE_ARRAY_BUFFER_LENGTH)
-                    }
+                val responseBody = InputStreamResource(result.data.file)
 
                 logger.trace(
-                    "[TemplateExportController.renderTemplateBatch()] success response: " +
-                        "(RenderTemplateBatchControllerResponse)"
+                    "[TemplateExportController.renderTemplateBatch()] success response: (batch file)"
                 )
 
                 ResponseEntity(
@@ -395,7 +349,7 @@ class TemplateExportController(
             }
 
             is Failure -> {
-                val errorStreamingBody = getErrorStreamingBody(result)
+                val errorBody = getErrorBody(result)
                 val headers = HttpHeaders()
                 headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 
@@ -411,7 +365,7 @@ class TemplateExportController(
                         else -> HttpStatus.INTERNAL_SERVER_ERROR
                     }
 
-                ResponseEntity(errorStreamingBody, headers, status)
+                ResponseEntity(errorBody, headers, status)
             }
         }
     }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/controller/ReportCalculationController.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/controller/ReportCalculationController.kt
@@ -4,7 +4,6 @@ import com.aamdigital.aambackendservice.common.domain.DomainReference
 import com.aamdigital.aambackendservice.common.domain.FileStorage
 import com.aamdigital.aambackendservice.common.error.HttpErrorDto
 import com.aamdigital.aambackendservice.common.error.NotFoundException
-import com.aamdigital.aambackendservice.common.stream.handleInputStreamToOutputStream
 import com.aamdigital.aambackendservice.export.controller.TemplateExportControllerResponse
 import com.aamdigital.aambackendservice.reporting.ConditionalOnReportingEnabled
 import com.aamdigital.aambackendservice.reporting.report.core.ReportStorage
@@ -16,6 +15,7 @@ import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateR
 import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationStorage
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
+import org.springframework.core.io.InputStreamResource
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -28,9 +28,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import java.io.InputStream
-import java.io.OutputStream
 import java.io.SequenceInputStream
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -138,16 +136,35 @@ class ReportCalculationController(
         return ResponseEntity.ok(toDto(reportCalculation))
     }
 
+    /**
+     * Streams the calculated data, wrapped in a small envelope of metadata.
+     *
+     * The body is an [InputStreamResource] and *not* a
+     * `org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody` on purpose.
+     * A StreamingResponseBody is written from an async task while the container owns the request
+     * lifecycle, so Tomcat could recycle the request underneath the writer - on the async timeout
+     * (30s by default, which by itself truncates large downloads) or when the client goes away.
+     * Both threads then touch the same `MimeHeaders`, which is not thread safe, and it fails with
+     * a NullPointerException from inside Tomcat while committing the response, sometimes taking
+     * whichever request next reuses the recycled objects with it. Neither Tomcat nor Spring treats
+     * that as fixable on their side (spring-framework#33439 was closed as not planned).
+     *
+     * Returning a Resource keeps the copy on the request thread, where the container cannot
+     * recycle anything until the handler returns. Virtual threads are enabled, so blocking that
+     * thread for the length of a download is cheap, and a client that disappears mid-download
+     * surfaces as a `ClientAbortException` that Spring's `DefaultHandlerExceptionResolver` logs at
+     * DEBUG. `ResourceHttpMessageConverter` copies the stream verbatim and closes it afterwards.
+     */
     @GetMapping("/{calculationId}/data", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun fetchReportCalculationData(
         @PathVariable("calculationId") calculationIdRaw: String
-    ): ResponseEntity<StreamingResponseBody> {
+    ): ResponseEntity<InputStreamResource> {
         // TODO Auth check (https://github.com/Aam-Digital/aam-services/issues/10)
 
         if (calculationIdRaw.isBlank() || calculationIdRaw.trim().isEmpty()) {
             logger.debug("[GET /{calculationId}/data]: Invalid calculationId $calculationIdRaw")
             return ResponseEntity(
-                getErrorStreamingBody(errorCode = "INVALID_DATA", "Invalid calculationId."),
+                getErrorBody(errorCode = "INVALID_DATA", "Invalid calculationId."),
                 HttpHeaders().apply {
                     set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 },
@@ -166,7 +183,7 @@ class ReportCalculationController(
             } catch (ex: NotFoundException) {
                 logger.trace("[GET /{calculationId}/data]: Requested calculationId $calculationId file not found")
                 return ResponseEntity(
-                    getErrorStreamingBody(errorCode = ex.code.toString(), ex.localizedMessage),
+                    getErrorBody(errorCode = ex.code.toString(), ex.localizedMessage),
                     HttpHeaders().apply {
                         set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     },
@@ -179,8 +196,10 @@ class ReportCalculationController(
                 reportCalculationStorage.fetchReportCalculation(DomainReference(id = calculationId))
             } catch (ex: NotFoundException) {
                 logger.trace("[GET /{calculationId}/data]: Requested calculationId $calculationId not found")
+                // nothing will consume the attachment stream that was opened above
+                file.close()
                 return ResponseEntity(
-                    getErrorStreamingBody(errorCode = ex.code.toString(), ex.localizedMessage),
+                    getErrorBody(errorCode = ex.code.toString(), ex.localizedMessage),
                     HttpHeaders().apply {
                         set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     },
@@ -189,26 +208,23 @@ class ReportCalculationController(
             }
 
         val responseBody =
-            StreamingResponseBody { outputStream: OutputStream ->
-                handleInputStreamToOutputStream(
-                    outputStream,
-                    SequenceInputStream(
-                        Collections.enumeration(
-                            listOf(
-                                (
-                                    "{\"id\": \"${calculationId}_data.json\"," +
-                                        "\"report\": {\"id\": \"${reportCalculation.report.id}\"}," +
-                                        "\"calculation\":{\"id\": \"$calculationId\"}," +
-                                        "\"dataHash\": \"${reportCalculation.attachments["data.json"]?.digest}\"," +
-                                        "\"data\":"
-                                ).byteInputStream(),
-                                file,
-                                "}".byteInputStream()
-                            )
+            InputStreamResource(
+                SequenceInputStream(
+                    Collections.enumeration(
+                        listOf(
+                            (
+                                "{\"id\": \"${calculationId}_data.json\"," +
+                                    "\"report\": {\"id\": \"${reportCalculation.report.id}\"}," +
+                                    "\"calculation\":{\"id\": \"$calculationId\"}," +
+                                    "\"dataHash\": \"${reportCalculation.attachments["data.json"]?.digest}\"," +
+                                    "\"data\":"
+                            ).byteInputStream(),
+                            file,
+                            "}".byteInputStream()
                         )
                     )
                 )
-            }
+            )
 
         logger.trace(
             "[GET /{calculationId}/data]: Returning stream for ${reportCalculation.report.id} calculationId $calculationId with ${reportCalculation.attachments["data.json"]?.digest}"
@@ -220,10 +236,16 @@ class ReportCalculationController(
             .body(responseBody)
     }
 
+    /**
+     * Streams the calculated data as it is stored, without the metadata envelope.
+     *
+     * Returns an [InputStreamResource] rather than a StreamingResponseBody for the reasons given
+     * on [fetchReportCalculationData].
+     */
     @GetMapping("/{calculationId}/data-stream", produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     fun fetchReportCalculationDataStream(
         @PathVariable calculationId: String
-    ): ResponseEntity<StreamingResponseBody> {
+    ): ResponseEntity<InputStreamResource> {
         val file =
             try {
                 fileStorage.fetchFile(
@@ -235,7 +257,7 @@ class ReportCalculationController(
                     "[GET /{calculationId}/data-stream]: Requested calculationId $calculationId file not found"
                 )
                 return ResponseEntity(
-                    getErrorStreamingBody(errorCode = ex.code.toString(), ex.localizedMessage),
+                    getErrorBody(errorCode = ex.code.toString(), ex.localizedMessage),
                     HttpHeaders().apply {
                         set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     },
@@ -248,8 +270,10 @@ class ReportCalculationController(
                 reportCalculationStorage.fetchReportCalculation(DomainReference(id = calculationId))
             } catch (ex: NotFoundException) {
                 logger.trace("[GET /{calculationId}/data-stream]: Requested calculationId $calculationId not found")
+                // nothing will consume the attachment stream that was opened above
+                file.close()
                 return ResponseEntity(
-                    getErrorStreamingBody(errorCode = ex.code.toString(), ex.localizedMessage),
+                    getErrorBody(errorCode = ex.code.toString(), ex.localizedMessage),
                     HttpHeaders().apply {
                         set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     },
@@ -257,10 +281,7 @@ class ReportCalculationController(
                 )
             }
 
-        val responseBody =
-            StreamingResponseBody { outputStream: OutputStream ->
-                handleInputStreamToOutputStream(outputStream, file)
-            }
+        val responseBody = InputStreamResource(file)
 
         logger.trace(
             "[GET /{calculationId}/data-stream]: Returning stream for ${reportCalculation.report.id} calculationId $calculationId"
@@ -273,31 +294,20 @@ class ReportCalculationController(
     }
 
     /*
-     * Needed to be able to return "ResponseEntity<StreamingResponseBody>" without the need to write a converter.
+     * Keeps the error responses the same body type as the success ones, so no converter is needed.
      */
-    private fun getErrorStreamingBody(
+    private fun getErrorBody(
         errorCode: String,
-        errorMessage: String,
-        byteArrayBufferLength: Int = 4096
-    ) = StreamingResponseBody { outputStream: OutputStream ->
-        val buffer = ByteArray(byteArrayBufferLength)
-        var bytesRead: Int
-
-        val bodyStream =
-            objectMapper
-                .writeValueAsString(
-                    TemplateExportControllerResponse.ErrorControllerResponse(
-                        errorCode = errorCode,
-                        errorMessage = errorMessage
-                    )
-                ).byteInputStream()
-
-        while ((bodyStream.read(buffer).also { bytesRead = it }) != -1) {
-            if (bytesRead > 0) {
-                outputStream.write(buffer, 0, bytesRead)
-            }
-        }
-    }
+        errorMessage: String
+    ) = InputStreamResource(
+        objectMapper
+            .writeValueAsString(
+                TemplateExportControllerResponse.ErrorControllerResponse(
+                    errorCode = errorCode,
+                    errorMessage = errorMessage
+                )
+            ).byteInputStream()
+    )
 
     private fun toDto(it: ReportCalculation): ReportCalculationDto {
         val result =

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/controller/TemplateExportControllerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/export/controller/TemplateExportControllerTest.kt
@@ -1,0 +1,222 @@
+package com.aamdigital.aambackendservice.export.controller
+
+import com.aamdigital.aambackendservice.common.domain.UseCaseOutcome
+import com.aamdigital.aambackendservice.export.core.CreateTemplateUseCase
+import com.aamdigital.aambackendservice.export.core.FetchTemplateData
+import com.aamdigital.aambackendservice.export.core.FetchTemplateError
+import com.aamdigital.aambackendservice.export.core.FetchTemplateUseCase
+import com.aamdigital.aambackendservice.export.core.RenderTemplateBatchData
+import com.aamdigital.aambackendservice.export.core.RenderTemplateBatchUseCase
+import com.aamdigital.aambackendservice.export.core.RenderTemplateData
+import com.aamdigital.aambackendservice.export.core.RenderTemplateUseCase
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ExtendWith(MockitoExtension::class)
+class TemplateExportControllerTest {
+    @Mock
+    private lateinit var createTemplateUseCase: CreateTemplateUseCase
+
+    @Mock
+    private lateinit var fetchTemplateUseCase: FetchTemplateUseCase
+
+    @Mock
+    private lateinit var renderTemplateUseCase: RenderTemplateUseCase
+
+    @Mock
+    private lateinit var renderTemplateBatchUseCase: RenderTemplateBatchUseCase
+
+    private lateinit var mockMvc: MockMvc
+
+    companion object {
+        private const val TEMPLATE_ID = "TemplateExport:1"
+
+        // a rendered file is binary; the high bytes also show that nothing re-encodes the payload
+        private val FILE_CONTENT = byteArrayOf(0x25, 0x50, 0x44, 0x46, -0x11, -0x42, 0x0a)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(
+                    TemplateExportController(
+                        createTemplateUseCase = createTemplateUseCase,
+                        fetchTemplateUseCase = fetchTemplateUseCase,
+                        renderTemplateUseCase = renderTemplateUseCase,
+                        renderTemplateBatchUseCase = renderTemplateBatchUseCase,
+                        objectMapper = ObjectMapper()
+                    )
+                ).build()
+    }
+
+    private fun fileHeaders(): HttpHeaders =
+        HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_OCTET_STREAM
+            set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=export.pdf")
+        }
+
+    @Test
+    fun `serves a template on the request thread instead of starting an async response`() {
+        // Given - a StreamingResponseBody would hand the write to an async task, which lets the
+        // container recycle the request underneath the writer
+        whenever(fetchTemplateUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Success(
+                    FetchTemplateData(
+                        file = FILE_CONTENT.inputStream(),
+                        responseHeaders = fileHeaders()
+                    )
+                )
+            )
+
+        // When
+        val result = mockMvc.perform(get("/v1/export/template/$TEMPLATE_ID"))
+
+        // Then
+        result
+            .andExpect(status().isOk)
+            .andExpect(request().asyncNotStarted())
+    }
+
+    @Test
+    fun `returns the template bytes unaltered, with the use case headers and no content length`() {
+        // Given
+        whenever(fetchTemplateUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Success(
+                    FetchTemplateData(
+                        file = FILE_CONTENT.inputStream(),
+                        responseHeaders = fileHeaders()
+                    )
+                )
+            )
+
+        // When
+        val response =
+            mockMvc
+                .perform(get("/v1/export/template/$TEMPLATE_ID"))
+                .andReturn()
+                .response
+
+        // Then
+        assertThat(response.contentAsByteArray).isEqualTo(FILE_CONTENT)
+        // A content length would mean the resource was drained to measure it, leaving an empty body
+        assertThat(response.getHeader(HttpHeaders.CONTENT_LENGTH)).isNull()
+        assertThat(response.getHeader(HttpHeaders.CONTENT_DISPOSITION))
+            .isEqualTo("attachment; filename=export.pdf")
+    }
+
+    @Test
+    fun `renders a template without starting an async response`() {
+        // Given
+        whenever(renderTemplateUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Success(
+                    RenderTemplateData(
+                        file = FILE_CONTENT.inputStream(),
+                        responseHeaders = fileHeaders()
+                    )
+                )
+            )
+
+        // When
+        val result =
+            mockMvc.perform(
+                post("/v1/export/render/$TEMPLATE_ID")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"Bärbel"}""")
+            )
+
+        // Then
+        result
+            .andExpect(status().isOk)
+            .andExpect(request().asyncNotStarted())
+        assertThat(result.andReturn().response.contentAsByteArray).isEqualTo(FILE_CONTENT)
+    }
+
+    @Test
+    fun `renders a batch without starting an async response`() {
+        // Given
+        whenever(renderTemplateBatchUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Success(
+                    RenderTemplateBatchData(
+                        file = FILE_CONTENT.inputStream(),
+                        responseHeaders = fileHeaders()
+                    )
+                )
+            )
+
+        // When
+        val result =
+            mockMvc.perform(
+                post("/v1/export/render-batch/$TEMPLATE_ID")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""[{"name":"Bärbel"}]""")
+            )
+
+        // Then
+        result
+            .andExpect(status().isOk)
+            .andExpect(request().asyncNotStarted())
+        assertThat(result.andReturn().response.contentAsByteArray).isEqualTo(FILE_CONTENT)
+    }
+
+    @Test
+    fun `answers with a json error body when the template is unknown`() {
+        // Given
+        whenever(fetchTemplateUseCase.run(any()))
+            .thenReturn(
+                UseCaseOutcome.Failure(
+                    errorCode = FetchTemplateError.NOT_FOUND_ERROR,
+                    errorMessage = "Template not found"
+                )
+            )
+
+        // When
+        val response =
+            mockMvc
+                .perform(get("/v1/export/template/$TEMPLATE_ID"))
+                .andReturn()
+                .response
+
+        // Then
+        assertThat(response.status).isEqualTo(404)
+        assertThat(response.contentType).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
+        assertThat(response.contentAsString).contains("NOT_FOUND_ERROR", "Template not found")
+    }
+
+    @Test
+    fun `rejects an unsupported batch mode with a json error body`() {
+        // When
+        val response =
+            mockMvc
+                .perform(
+                    post("/v1/export/render-batch/$TEMPLATE_ID")
+                        .param("mode", "unsupported")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""[{"name":"Bärbel"}]""")
+                ).andReturn()
+                .response
+
+        // Then
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.contentAsString).contains("INVALID_MODE", "Allowed values: zip, combined.")
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/controller/ReportCalculationControllerTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/reporting/reportcalculation/controller/ReportCalculationControllerTest.kt
@@ -1,0 +1,210 @@
+package com.aamdigital.aambackendservice.reporting.reportcalculation.controller
+
+import com.aamdigital.aambackendservice.common.couchdb.dto.AttachmentMetaData
+import com.aamdigital.aambackendservice.common.domain.DomainReference
+import com.aamdigital.aambackendservice.common.domain.FileStorage
+import com.aamdigital.aambackendservice.common.error.NotFoundException
+import com.aamdigital.aambackendservice.reporting.report.core.ReportStorage
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculation
+import com.aamdigital.aambackendservice.reporting.reportcalculation.ReportCalculationStatus
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.CreateReportCalculationUseCase
+import com.aamdigital.aambackendservice.reporting.reportcalculation.core.ReportCalculationStorage
+import com.aamdigital.aambackendservice.reporting.reportcalculation.storage.DefaultReportCalculationStorage.DefaultReportCalculationStorageError
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+@ExtendWith(MockitoExtension::class)
+class ReportCalculationControllerTest {
+    @Mock
+    private lateinit var reportStorage: ReportStorage
+
+    @Mock
+    private lateinit var reportCalculationStorage: ReportCalculationStorage
+
+    @Mock
+    private lateinit var fileStorage: FileStorage
+
+    @Mock
+    private lateinit var createReportCalculationUseCase: CreateReportCalculationUseCase
+
+    private lateinit var mockMvc: MockMvc
+
+    companion object {
+        private const val CALCULATION_ID = "ReportCalculation:1"
+        private const val DATA = """[{"name":"Bärbel"}]"""
+    }
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(
+                    ReportCalculationController(
+                        reportStorage = reportStorage,
+                        reportCalculationStorage = reportCalculationStorage,
+                        fileStorage = fileStorage,
+                        createReportCalculationUseCase = createReportCalculationUseCase,
+                        objectMapper = ObjectMapper()
+                    )
+                ).build()
+    }
+
+    private fun storedCalculation(): ReportCalculation =
+        ReportCalculation(
+            id = CALCULATION_ID,
+            report = DomainReference(id = "ReportConfig:1"),
+            status = ReportCalculationStatus.FINISHED_SUCCESS,
+            attachments =
+                mutableMapOf(
+                    "data.json" to
+                        AttachmentMetaData(
+                            contentType = "application/json",
+                            revpos = 2,
+                            digest = "md5-someDigest",
+                            length = DATA.length.toLong(),
+                            stub = true
+                        )
+                )
+        )
+
+    @Test
+    fun `writes the data on the request thread instead of starting an async response`() {
+        // Given - a StreamingResponseBody would hand the write to an async task, which lets the
+        // container recycle the request underneath the writer
+        whenever(fileStorage.fetchFile(path = "report-calculation/$CALCULATION_ID", fileName = "data.json"))
+            .thenReturn(DATA.byteInputStream())
+        whenever(reportCalculationStorage.fetchReportCalculation(DomainReference(id = CALCULATION_ID)))
+            .thenReturn(storedCalculation())
+
+        // When
+        val result = mockMvc.perform(get("/v1/reporting/report-calculation/$CALCULATION_ID/data"))
+
+        // Then
+        result
+            .andExpect(status().isOk)
+            .andExpect(request().asyncNotStarted())
+    }
+
+    @Test
+    fun `returns the stored data wrapped in the metadata envelope, unaltered and without a content length`() {
+        // Given
+        whenever(fileStorage.fetchFile(path = "report-calculation/$CALCULATION_ID", fileName = "data.json"))
+            .thenReturn(DATA.byteInputStream())
+        whenever(reportCalculationStorage.fetchReportCalculation(DomainReference(id = CALCULATION_ID)))
+            .thenReturn(storedCalculation())
+
+        // When
+        val response =
+            mockMvc
+                .perform(get("/v1/reporting/report-calculation/$CALCULATION_ID/data"))
+                .andReturn()
+                .response
+
+        // Then
+        assertThat(response.contentAsString).isEqualTo(
+            """{"id": "${CALCULATION_ID}_data.json",""" +
+                """"report": {"id": "ReportConfig:1"},""" +
+                """"calculation":{"id": "$CALCULATION_ID"},""" +
+                """"dataHash": "md5-someDigest",""" +
+                """"data":$DATA}"""
+        )
+        // A content length would mean the resource was drained to measure it, leaving an empty body
+        assertThat(response.getHeader(HttpHeaders.CONTENT_LENGTH)).isNull()
+        assertThat(response.getHeader(HttpHeaders.CONTENT_DISPOSITION))
+            .isEqualTo("attachment; filename=$CALCULATION_ID-data.json")
+    }
+
+    @Test
+    fun `returns the stored data as-is on the data-stream endpoint`() {
+        // Given
+        whenever(fileStorage.fetchFile(path = "report-calculation/$CALCULATION_ID", fileName = "data.json"))
+            .thenReturn(DATA.byteInputStream())
+        whenever(reportCalculationStorage.fetchReportCalculation(DomainReference(id = CALCULATION_ID)))
+            .thenReturn(storedCalculation())
+
+        // When
+        val response =
+            mockMvc
+                .perform(get("/v1/reporting/report-calculation/$CALCULATION_ID/data-stream"))
+                .andReturn()
+                .response
+
+        // Then
+        assertThat(response.status).isEqualTo(200)
+        assertThat(response.contentAsString).isEqualTo(DATA)
+    }
+
+    @Test
+    fun `answers with a json error body when the calculation is unknown`() {
+        // Given
+        whenever(fileStorage.fetchFile(path = "report-calculation/$CALCULATION_ID", fileName = "data.json"))
+            .thenReturn(DATA.byteInputStream())
+        whenever(reportCalculationStorage.fetchReportCalculation(DomainReference(id = CALCULATION_ID)))
+            .thenThrow(
+                NotFoundException(
+                    message = "Could not find reportCalculation",
+                    code = DefaultReportCalculationStorageError.NOT_FOUND
+                )
+            )
+
+        // When
+        val response =
+            mockMvc
+                .perform(get("/v1/reporting/report-calculation/$CALCULATION_ID/data"))
+                .andReturn()
+                .response
+
+        // Then
+        assertThat(response.status).isEqualTo(404)
+        assertThat(response.contentAsString).contains("NOT_FOUND", "Could not find reportCalculation")
+    }
+
+    @Test
+    fun `closes the attachment stream when the calculation lookup fails afterwards`() {
+        // Given - the stream is opened before the lookup, so nothing would ever consume or close it
+        val attachment = CloseRecordingInputStream(DATA.byteInputStream())
+        whenever(fileStorage.fetchFile(path = "report-calculation/$CALCULATION_ID", fileName = "data.json"))
+            .thenReturn(attachment)
+        whenever(reportCalculationStorage.fetchReportCalculation(DomainReference(id = CALCULATION_ID)))
+            .thenThrow(
+                NotFoundException(
+                    message = "Could not find reportCalculation",
+                    code = DefaultReportCalculationStorageError.NOT_FOUND
+                )
+            )
+
+        // When
+        mockMvc.perform(get("/v1/reporting/report-calculation/$CALCULATION_ID/data"))
+
+        // Then
+        assertThat(attachment.closed).isTrue()
+    }
+
+    private class CloseRecordingInputStream(
+        private val delegate: ByteArrayInputStream
+    ) : InputStream() {
+        var closed = false
+            private set
+
+        override fun read(): Int = delegate.read()
+
+        override fun close() {
+            closed = true
+            delegate.close()
+        }
+    }
+}


### PR DESCRIPTION
Five Sentry issues report `NullPointerException`s thrown from inside Tomcat's own header table
(`MimeHeaders.headers[i] is null`), unhandled and at fatal level, on the report data download
endpoint. They are one fault, and the trigger is on our side.

## Mechanism

Every endpoint that streams a file returned a `StreamingResponseBody`, so the body was written
from an async task while the container kept ownership of the request lifecycle. Tomcat could
therefore recycle the request underneath the writer — on the async timeout (30s by default) or
when the client went away (two of the five issues carry a `GET /error` transaction, which is that
error dispatch). Both threads then mutate the same `MimeHeaders`: `createHeader` grows the array
and increments `count` without synchronisation, so another thread reads a slot that is not
populated yet. Because Tomcat pools request and response objects, the corruption can also reach
whichever request next reuses them.

Neither project treats this as fixable on their side — Tomcat's `MimeHeaders` is documented as not
thread safe, and [spring-framework#33439](https://github.com/spring-projects/spring-framework/issues/33439)
was closed as not planned — so there is no upstream patch to pick up.

## Change

The file-returning endpoints now answer with an `InputStreamResource` instead of a
`StreamingResponseBody`, so the copy happens on the request thread, where the container cannot
recycle anything until the handler returns. That removes the race by construction rather than
narrowing the window. Virtual threads are already enabled, so holding a thread for the length of a
download is cheap, and a client that disappears mid-download surfaces as a `ClientAbortException`
that Spring's `DefaultHandlerExceptionResolver` resolves and logs at DEBUG — so this does not
trade the NPEs for a broken-pipe issue.

- `ReportCalculationController`: `/data` and `/data-stream` (where all the events occurred). Also
  closes the attachment stream on the error path where the calculation lookup fails after the
  attachment was already opened.
- `TemplateExportController`: `/template/{id}`, `/render/{id}` and `/render-batch/{id}`. No events
  have been observed there — the rendered files are small and quick — but the exposure is
  identical. The three `StreamingResponseBody`-extending members of
  `TemplateExportControllerResponse` existed only to carry that body type and nothing referenced
  them, so they are removed rather than reworked.

Response bytes, headers and status codes are unchanged on every path.

## Side effect worth knowing

The async timeout defaults to 30 seconds, so any download slower than that was being torn down
mid-write. That was a user-visible bug nobody had filed, and it is fixed by the same change.

## Verification

11 new controller tests assert that no async response is started (`asyncNotStarted()` — the
discriminator that the async lifecycle is really gone), that the bytes come through unaltered
(including multi-byte and binary payloads), and that no `Content-Length` is set — a length would
mean the resource had been drained to measure it, leaving an empty body. Full suite green
(`tests=317 failures=0`), including the Cucumber end-to-end scenarios that exercise both the
report data and the template export endpoints against real containers.

What this cannot claim: the race was never reproduced locally, so this removes the mechanism by
construction rather than being verified fixed. The five issues are referenced, not closed, so they
stay open to watch.

Refs AAM-BACKEND-SERVICE-8H, AAM-BACKEND-SERVICE-8M, AAM-BACKEND-SERVICE-8K,
AAM-BACKEND-SERVICE-8J, AAM-BACKEND-SERVICE-8N

Note for reviewers: `handleInputStreamToOutputStream` is no longer used by these download paths
(they now go through `ResourceHttpMessageConverter`), but it is still used for uploads, so the
chunk-boundary fix on `fix/utf8-corruption-in-stream-copy` remains relevant and independent. The
byte-exact assertions in the new tests cover the download paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Template exports and report downloads now provide responses directly, improving compatibility and consistency for download requests.
  - Template fetch, single-render, batch-render, and report data endpoints continue to preserve binary content, response headers, metadata, and status handling.
  - Error responses remain available as structured JSON for missing resources, unknown calculations, and unsupported modes.

- **Tests**
  - Added coverage for successful downloads, metadata-wrapped reports, binary content preservation, response headers, error handling, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->