### PR TITLE
fix(logging): report each recurring fault as one Sentry issue

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessor.kt
@@ -1,0 +1,69 @@
+package com.aamdigital.aambackendservice.common.rest.di
+
+import io.sentry.EventProcessor
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import org.springframework.stereotype.Component
+
+/**
+ * Collapses the NullPointerExceptions that Tomcat throws from its own header table into one Sentry
+ * issue.
+ *
+ * They surface while a response is committed or recycled - the streaming download endpoints reach
+ * this code path from an async task, so the container can be tearing the request down while the
+ * body is still being written. Tomcat's `MimeHeaders.headers[]` is then partly nulled and whichever
+ * method touches it next fails.
+ *
+ * The exception message names that method and the loop variable of the frame that dereferenced the
+ * entry, and the transaction is sometimes lost with the recycled request, so production produced
+ * five separate issues (`MimeHeaderField.getName()`, `.recycle()`, `this.headers[i]`,
+ * `this.headers[n]`, with and without a transaction) for a fault that always originates in the same
+ * place. None of them individually accumulated enough events to escalate.
+ *
+ * Grouping on "an NPE thrown inside [MIME_HEADERS_CLASS]" keeps them together while staying
+ * agnostic about the calling code, whose frames differ per endpoint and change as the streaming
+ * helpers evolve. This is a grouping change only: the events keep their stack traces, `handled`
+ * flag and level, so the underlying race stays visible - and now countable - rather than silenced.
+ */
+@Component
+class HttpResponseSentryEventProcessor : EventProcessor {
+    override fun process(
+        event: SentryEvent,
+        hint: Hint
+    ): SentryEvent {
+        if (isMimeHeadersFailure(event.throwable)) {
+            event.fingerprints = listOf(MIME_HEADERS_FINGERPRINT)
+        }
+
+        return event
+    }
+
+    /**
+     * The NPE is sometimes reported as the cause of a wrapper, so the whole chain is checked. The
+     * depth bound guards against self-referential chains.
+     */
+    private fun isMimeHeadersFailure(throwable: Throwable?): Boolean {
+        var cause = throwable
+        var depth = 0
+
+        while (cause != null && depth < MAX_CAUSE_DEPTH) {
+            if (cause is NullPointerException &&
+                cause.stackTrace.firstOrNull()?.className == MIME_HEADERS_CLASS
+            ) {
+                return true
+            }
+
+            cause = cause.cause
+            depth += 1
+        }
+
+        return false
+    }
+
+    companion object {
+        const val MIME_HEADERS_CLASS = "org.apache.tomcat.util.http.MimeHeaders"
+        const val MIME_HEADERS_FINGERPRINT = "tomcat-mime-headers-recycled-during-response"
+
+        private const val MAX_CAUSE_DEPTH = 10
+    }
+}

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
@@ -3,7 +3,10 @@ package com.aamdigital.aambackendservice.common.storage.di
 import io.sentry.EventProcessor
 import io.sentry.Hint
 import io.sentry.SentryEvent
+import org.hibernate.exception.JDBCConnectionException
+import org.springframework.jdbc.CannotGetJdbcConnectionException
 import org.springframework.stereotype.Component
+import java.sql.SQLException
 
 /**
  * Gives database errors a Sentry grouping key that stays stable across occurrences.
@@ -15,14 +18,28 @@ import org.springframework.stereotype.Component
  * backs off and retries. The service therefore recovers on its own; what it does not do is
  * report the failure as one recurring fault.
  *
- * HikariCP interpolates the elapsed wait and the pool counts into its message
- * ("... request timed out after 37386ms (total=7, active=0, idle=6, waiting=0)"), so no two
- * occurrences look alike and a single fault spreads across new Sentry issues as it recurs. That
- * splits the per-issue event counts which `archived_until_escalating` uses to decide whether to
- * escalate, so a recurring fault can stay archived while tracking real production outages.
+ * A single episode of "Postgres is unreachable" reaches Sentry through several channels that all
+ * describe the same fault:
+ *  - the driver's own wording, which differs per failure mode ("An I/O error occurred while
+ *    sending to the backend.", "This connection has been closed.", "The connection attempt
+ *    failed."),
+ *  - HikariCP's pool timeout, which interpolates the elapsed wait and the pool counts
+ *    ("... request timed out after 37386ms (total=7, active=0, idle=6, waiting=0)"),
+ *  - the translated [JDBCConnectionException] that Spring's transaction interceptor logs with the
+ *    failing statement embedded in the message.
  *
- * Replacing digit runs in the message collapses the interpolated variants into one issue while
- * keeping genuinely different SQL errors (constraint violations and the like) apart.
+ * Each wording became its own Sentry issue, so one outage arrived as five unrelated-looking
+ * issues, and the per-issue event counts that `archived_until_escalating` uses to decide whether
+ * to escalate were split five ways.
+ *
+ * Connection faults are therefore collapsed onto [CONNECTION_FINGERPRINT], recognised from the
+ * SQL standard's class-08 SQLState ("connection exception") or from the framework wrapper types
+ * that stand for it. `server_name` stays on every event, so a single-instance outage remains
+ * distinguishable from a shared-infrastructure one by filtering inside the issue.
+ *
+ * Everything else Hibernate logs - constraint violations and the like - keeps a per-message
+ * fingerprint with digit runs replaced, which collapses interpolated variants without merging
+ * genuinely different SQL errors.
  */
 @Component
 class DatabaseSentryEventProcessor : EventProcessor {
@@ -30,6 +47,11 @@ class DatabaseSentryEventProcessor : EventProcessor {
         event: SentryEvent,
         hint: Hint
     ): SentryEvent {
+        if (isConnectionFault(event.throwable)) {
+            event.fingerprints = listOf(CONNECTION_FINGERPRINT)
+            return event
+        }
+
         if (event.logger != SQL_EXCEPTION_LOGGER) {
             return event
         }
@@ -38,14 +60,69 @@ class DatabaseSentryEventProcessor : EventProcessor {
         val message = event.message?.formatted ?: event.message?.message ?: event.throwable?.message
 
         if (message != null) {
-            event.fingerprints = listOf(SQL_EXCEPTION_LOGGER, message.replace(INTERPOLATED_NUMBERS, "#"))
+            event.fingerprints =
+                if (CONNECTION_FAULT_MESSAGES.any { message.contains(it) }) {
+                    // These events carry no throwable, so the SQLState is unavailable and the
+                    // driver's wording is all there is to match on. Scoping the match to
+                    // Hibernate's SQL exception logger keeps it from reaching other events.
+                    listOf(CONNECTION_FINGERPRINT)
+                } else {
+                    listOf(SQL_EXCEPTION_LOGGER, message.replace(INTERPOLATED_NUMBERS, "#"))
+                }
         }
 
         return event
     }
 
+    /**
+     * Walks the cause chain for a lost or unobtainable database connection. The depth bound guards
+     * against self-referential chains, which some drivers produce.
+     */
+    private fun isConnectionFault(throwable: Throwable?): Boolean {
+        var cause = throwable
+        var depth = 0
+
+        while (cause != null && depth < MAX_CAUSE_DEPTH) {
+            if (cause is JDBCConnectionException || cause is CannotGetJdbcConnectionException) {
+                return true
+            }
+
+            // The SQL standard reserves SQLState class 08 for connection exceptions; the PostgreSQL
+            // driver and HikariCP's pool timeout both report it.
+            if (cause is SQLException && cause.sqlState?.startsWith(CONNECTION_SQL_STATE_CLASS) == true) {
+                return true
+            }
+
+            cause = cause.cause
+            depth += 1
+        }
+
+        return false
+    }
+
     companion object {
         const val SQL_EXCEPTION_LOGGER = "org.hibernate.engine.jdbc.spi.SqlExceptionHelper"
+        const val CONNECTION_FINGERPRINT = "database-connection-unavailable"
+
+        private const val CONNECTION_SQL_STATE_CLASS = "08"
+        private const val MAX_CAUSE_DEPTH = 10
         private val INTERPOLATED_NUMBERS = Regex("\\d+")
+
+        /**
+         * Wordings observed in production for a database that went away, as logged without a
+         * throwable. Kept deliberately short: a wording that is not listed still groups by its
+         * normalised message, which is a smaller failure than mistaking an unrelated error for a
+         * connection fault.
+         */
+        private val CONNECTION_FAULT_MESSAGES =
+            listOf(
+                "An I/O error occurred while sending to the backend.",
+                "This connection has been closed.",
+                "The connection attempt failed.",
+                "Connection is not available, request timed out after",
+                "Connection refused",
+                "Connection reset",
+                "terminating connection"
+            )
     }
 }

--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessor.kt
@@ -87,8 +87,9 @@ class DatabaseSentryEventProcessor : EventProcessor {
                 return true
             }
 
-            // The SQL standard reserves SQLState class 08 for connection exceptions; the PostgreSQL
-            // driver and HikariCP's pool timeout both report it.
+            // The SQL standard reserves SQLState class 08 for connection exceptions, which is what
+            // the PostgreSQL driver reports for a socket that went away. Pool timeouts reach this
+            // check through the wrapper types above once Hibernate has translated them.
             if (cause is SQLException && cause.sqlState?.startsWith(CONNECTION_SQL_STATE_CLASS) == true) {
                 return true
             }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessorTest.kt
@@ -1,0 +1,136 @@
+package com.aamdigital.aambackendservice.common.rest.di
+
+import com.aamdigital.aambackendservice.common.rest.di.HttpResponseSentryEventProcessor.Companion.MIME_HEADERS_CLASS
+import com.aamdigital.aambackendservice.common.rest.di.HttpResponseSentryEventProcessor.Companion.MIME_HEADERS_FINGERPRINT
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import io.sentry.exception.ExceptionMechanismException
+import io.sentry.protocol.Mechanism
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HttpResponseSentryEventProcessorTest {
+    private val processor = HttpResponseSentryEventProcessor()
+
+    /**
+     * Rebuilds what production reported: an NPE whose throw site is inside Tomcat's header table,
+     * with the message naming the accessor and the loop variable of the failing frame.
+     */
+    private fun mimeHeadersFailure(
+        message: String,
+        method: String
+    ): NullPointerException =
+        NullPointerException(message).apply {
+            stackTrace =
+                arrayOf(
+                    StackTraceElement(MIME_HEADERS_CLASS, method, "MimeHeaders.java", 319),
+                    StackTraceElement(
+                        "org.apache.coyote.http11.Http11Processor",
+                        "prepareResponse",
+                        "Http11Processor.java",
+                        939
+                    )
+                )
+        }
+
+    @Test
+    fun `groups the header table failures that differ only in accessor and loop variable`() {
+        // Given - the distinct exception messages production reported for this fault
+        val failures =
+            listOf(
+                mimeHeadersFailure(
+                    "Cannot invoke \"org.apache.tomcat.util.http.MimeHeaderField.getName()\" " +
+                        "because \"this.headers[i]\" is null",
+                    "setValue"
+                ),
+                mimeHeadersFailure(
+                    "Cannot invoke \"org.apache.tomcat.util.http.MimeHeaderField.getName()\" " +
+                        "because \"this.headers[n]\" is null",
+                    "getValue"
+                ),
+                mimeHeadersFailure(
+                    "Cannot invoke \"org.apache.tomcat.util.http.MimeHeaderField.recycle()\" " +
+                        "because \"this.headers[i]\" is null",
+                    "recycle"
+                )
+            )
+
+        // When
+        val fingerprints = failures.map { processor.process(SentryEvent(it), Hint()).fingerprints }
+
+        // Then
+        assertThat(fingerprints).containsOnly(listOf(MIME_HEADERS_FINGERPRINT))
+    }
+
+    @Test
+    fun `groups the failure when it arrives wrapped in the sentry exception mechanism`() {
+        // Given - the logback integration wraps the throwable before handing it to the processors
+        val failure =
+            mimeHeadersFailure(
+                "Cannot invoke \"org.apache.tomcat.util.http.MimeHeaderField.getName()\" " +
+                    "because \"this.headers[i]\" is null",
+                "setValue"
+            )
+        val event = SentryEvent(ExceptionMechanismException(Mechanism(), failure, Thread.currentThread()))
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result.fingerprints).containsExactly(MIME_HEADERS_FINGERPRINT)
+    }
+
+    @Test
+    fun `groups the failure when it is reported as the cause of a wrapper`() {
+        // Given
+        val failure =
+            mimeHeadersFailure(
+                "Cannot invoke \"org.apache.tomcat.util.http.MimeHeaderField.getName()\" " +
+                    "because \"this.headers[i]\" is null",
+                "setValue"
+            )
+        val event = SentryEvent(IllegalStateException("Async processing failed", failure))
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result.fingerprints).containsExactly(MIME_HEADERS_FINGERPRINT)
+    }
+
+    @Test
+    fun `leaves application NullPointerExceptions untouched`() {
+        // Given - an NPE thrown in our own code must keep Sentry's default grouping
+        val applicationFailure =
+            NullPointerException("Cannot invoke \"String.length()\" because \"name\" is null").apply {
+                stackTrace =
+                    arrayOf(
+                        StackTraceElement(
+                            "com.aamdigital.aambackendservice.reporting.report.ReportService",
+                            "calculate",
+                            "ReportService.kt",
+                            42
+                        )
+                    )
+            }
+
+        // When
+        val result = processor.process(SentryEvent(applicationFailure), Hint())
+
+        // Then
+        assertThat(result.fingerprints).isNull()
+    }
+
+    @Test
+    fun `leaves events without a throwable untouched`() {
+        // Given
+        val event = SentryEvent()
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result).isSameAs(event)
+        assertThat(result.fingerprints).isNull()
+    }
+}

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/rest/di/HttpResponseSentryEventProcessorTest.kt
@@ -1,5 +1,6 @@
 package com.aamdigital.aambackendservice.common.rest.di
 
+import com.aamdigital.aambackendservice.Application
 import com.aamdigital.aambackendservice.common.rest.di.HttpResponseSentryEventProcessor.Companion.MIME_HEADERS_CLASS
 import com.aamdigital.aambackendservice.common.rest.di.HttpResponseSentryEventProcessor.Companion.MIME_HEADERS_FINGERPRINT
 import io.sentry.Hint
@@ -8,6 +9,7 @@ import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.Mechanism
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 
 class HttpResponseSentryEventProcessorTest {
     private val processor = HttpResponseSentryEventProcessor()
@@ -32,6 +34,20 @@ class HttpResponseSentryEventProcessorTest {
                     )
                 )
         }
+
+    @Test
+    fun `is discoverable by the application's component scan`() {
+        // Given - Sentry only consults processors that made it into the context, and this one lives
+        // in a package that had no beans before, so verify the scan reaches it
+        val scanner = ClassPathScanningCandidateComponentProvider(true)
+
+        // When
+        val components = scanner.findCandidateComponents(Application::class.java.packageName)
+
+        // Then
+        assertThat(components.map { it.beanClassName })
+            .contains(HttpResponseSentryEventProcessor::class.java.name)
+    }
 
     @Test
     fun `groups the header table failures that differ only in accessor and loop variable`() {

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
@@ -1,11 +1,17 @@
 package com.aamdigital.aambackendservice.common.storage.di
 
+import com.aamdigital.aambackendservice.common.storage.di.DatabaseSentryEventProcessor.Companion.CONNECTION_FINGERPRINT
 import com.aamdigital.aambackendservice.common.storage.di.DatabaseSentryEventProcessor.Companion.SQL_EXCEPTION_LOGGER
 import io.sentry.Hint
 import io.sentry.SentryEvent
+import io.sentry.exception.ExceptionMechanismException
+import io.sentry.protocol.Mechanism
 import io.sentry.protocol.Message
 import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.exception.JDBCConnectionException
 import org.junit.jupiter.api.Test
+import java.sql.SQLException
+import java.sql.SQLTransientConnectionException
 
 class DatabaseSentryEventProcessorTest {
     private val processor = DatabaseSentryEventProcessor()
@@ -19,6 +25,8 @@ class DatabaseSentryEventProcessorTest {
             this.message = Message().apply { formatted = message }
         }
 
+    private fun exceptionEvent(throwable: Throwable): SentryEvent = SentryEvent(throwable)
+
     @Test
     fun `leaves events from other loggers untouched`() {
         // Given
@@ -29,6 +37,18 @@ class DatabaseSentryEventProcessorTest {
 
         // Then
         assertThat(result).isSameAs(event)
+        assertThat(result.fingerprints).isNull()
+    }
+
+    @Test
+    fun `leaves unrelated exceptions untouched`() {
+        // Given - a connection failure against a different system must not look like a database one
+        val event = exceptionEvent(IllegalStateException("502 Bad Gateway on GET request for certs"))
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
         assertThat(result.fingerprints).isNull()
     }
 
@@ -50,12 +70,66 @@ class DatabaseSentryEventProcessorTest {
         val longWaitResult = processor.process(longWait, Hint())
 
         // Then
-        assertThat(shortWaitResult.fingerprints).isEqualTo(longWaitResult.fingerprints)
-        assertThat(shortWaitResult.fingerprints).containsExactly(
-            SQL_EXCEPTION_LOGGER,
-            "HikariPool-# - Connection is not available, request timed out after #ms " +
-                "(total=#, active=#, idle=#, waiting=#)"
-        )
+        assertThat(shortWaitResult.fingerprints).containsExactly(CONNECTION_FINGERPRINT)
+        assertThat(longWaitResult.fingerprints).isEqualTo(shortWaitResult.fingerprints)
+    }
+
+    @Test
+    fun `groups the driver wordings of a lost connection into one issue`() {
+        // Given - the messages Hibernate logged for one production outage, each its own issue before
+        val messages =
+            listOf(
+                "An I/O error occurred while sending to the backend.",
+                "This connection has been closed.",
+                "The connection attempt failed.",
+                "HikariPool-1 - Connection is not available, request timed out after 269290ms " +
+                    "(total=8, active=0, idle=8, waiting=0)"
+            )
+
+        // When
+        val fingerprints = messages.map { processor.process(sqlEvent(it), Hint()).fingerprints }
+
+        // Then
+        assertThat(fingerprints).containsOnly(listOf(CONNECTION_FINGERPRINT))
+    }
+
+    @Test
+    fun `groups the translated connection exception with the logged driver wordings`() {
+        // Given - the same outage as reported by the transaction interceptor, statement included
+        val event =
+            exceptionEvent(
+                JDBCConnectionException(
+                    "JDBC exception executing SQL [select se1_0.id from couchdb_sync_entry se1_0 where se1_0.id=?]",
+                    SQLException(
+                        "An I/O error occurred while sending to the backend.",
+                        // SQLState 08006, "connection failure", as the PostgreSQL driver reports it
+                        "08006"
+                    )
+                )
+            )
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result.fingerprints).containsExactly(CONNECTION_FINGERPRINT)
+    }
+
+    @Test
+    fun `groups a connection fault reported through the sentry exception mechanism`() {
+        // Given - the logback integration wraps the throwable before handing it to the processors
+        val poolTimeout =
+            SQLTransientConnectionException(
+                "HikariPool-1 - Connection is not available, request timed out after 30000ms",
+                "08003"
+            )
+        val event = exceptionEvent(ExceptionMechanismException(Mechanism(), poolTimeout, Thread.currentThread()))
+
+        // When
+        val result = processor.process(event, Hint())
+
+        // Then
+        assertThat(result.fingerprints).containsExactly(CONNECTION_FINGERPRINT)
     }
 
     @Test
@@ -69,6 +143,10 @@ class DatabaseSentryEventProcessorTest {
         val constraintViolationResult = processor.process(constraintViolation, Hint())
 
         // Then
+        assertThat(constraintViolationResult.fingerprints).containsExactly(
+            SQL_EXCEPTION_LOGGER,
+            "ERROR: duplicate key value violates unique constraint"
+        )
         assertThat(connectionClosedResult.fingerprints)
             .isNotEqualTo(constraintViolationResult.fingerprints)
     }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/common/storage/di/DatabaseSentryEventProcessorTest.kt
@@ -118,12 +118,13 @@ class DatabaseSentryEventProcessorTest {
     @Test
     fun `groups a connection fault reported through the sentry exception mechanism`() {
         // Given - the logback integration wraps the throwable before handing it to the processors
-        val poolTimeout =
+        val connectionLost =
             SQLTransientConnectionException(
-                "HikariPool-1 - Connection is not available, request timed out after 30000ms",
+                "Connection is not available",
+                // any class-08 SQLState stands for "connection exception"
                 "08003"
             )
-        val event = exceptionEvent(ExceptionMechanismException(Mechanism(), poolTimeout, Thread.currentThread()))
+        val event = exceptionEvent(ExceptionMechanismException(Mechanism(), connectionLost, Thread.currentThread()))
 
         // When
         val result = processor.process(event, Hint())


### PR DESCRIPTION
Ten of the thirteen unresolved Sentry issues in the backend project are two faults, each split
across five issues by how Sentry fingerprints them.

## Family A — a lost database connection, reported five ways

All five come from the same code path (the scheduled CouchDB change poller reading its sync entry)
and the same fault: PostgreSQL unreachable. They split because each channel words it differently:

- Hibernate logs the failure at ERROR *before* the exception propagates, and those events carry no
  throwable — so Sentry groups them by message text, and the driver has one wording per failure
  mode ("An I/O error occurred while sending to the backend.", "This connection has been closed.",
  "The connection attempt failed."), plus HikariCP's pool timeout.
- The same failure arrives again as a real exception, logged by Spring's transaction interceptor
  with the failing statement embedded in the title.

Connection faults now share one fingerprint, recognised from the SQL standard's class-08 SQLState
or the framework wrapper types that stand for it — typed, not message text, so an unrelated error
that merely mentions a connection is unaffected. Only the throwable-less Hibernate log events fall
back to a message match, scoped to that one logger. Other SQL errors keep their per-message
fingerprint.

Two deliberate trade-offs: the fingerprint collapses across severity (a request that 500s because
the database is unreachable lands in the same issue as the poller's self-recovering noise) and
across instances. `transaction` and `server_name` stay queryable inside the issue.

## Family B — one Tomcat header-table race, reported five ways

`NullPointerException`s thrown inside Tomcat's `MimeHeaders` while a response is committed or
recycled. They split because the exception message names both the accessor and the loop variable
of the failing frame (`getName()`/`recycle()`, `headers[i]`/`headers[n]`), and the transaction is
sometimes lost with the recycled request. They now share a fingerprint keyed on "an NPE thrown
inside Tomcat's `MimeHeaders`", which is stable as the calling code evolves.

This is grouping only — stack traces, the `handled` flag and the level are untouched, so the
underlying race stays visible and becomes countable. The fix for it is a separate PR.

## Notes

- Fingerprint changes are not retroactive: after deploy the ten existing issues go quiet and two
  new ones appear. The old groups need **Merge** (or resolve) by hand.
- One test asserts the new processor is reachable by the application's component scan — this
  repository has already shipped a Sentry event processor that was a silent no-op in production.
- Not covered here: the SQS report-query rejection is a separate real bug, not a grouping artifact.

Full suite green (`tests=316 failures=0`).

Refs AAM-BACKEND-SERVICE-8S, AAM-BACKEND-SERVICE-8Q, AAM-BACKEND-SERVICE-8P,
AAM-BACKEND-SERVICE-8R, AAM-BACKEND-SERVICE-8V, AAM-BACKEND-SERVICE-8H, AAM-BACKEND-SERVICE-8M,
AAM-BACKEND-SERVICE-8K, AAM-BACKEND-SERVICE-8J, AAM-BACKEND-SERVICE-8N

🤖 Generated with [Claude Code](https://claude.com/claude-code)
