### PR TITLE
fix(notification): give the dead letter drain a channel-transacted template

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationQueueConfiguration.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationQueueConfiguration.kt
@@ -19,6 +19,7 @@ import org.springframework.amqp.core.BindingBuilder
 import org.springframework.amqp.core.FanoutExchange
 import org.springframework.amqp.core.Queue
 import org.springframework.amqp.core.QueueBuilder
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.amqp.rabbit.retry.MessageRecoverer
 import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer
@@ -109,10 +110,24 @@ class NotificationQueueConfiguration {
             rabbitTemplate = rabbitTemplate
         )
 
+    /**
+     * A dedicated template for [NotificationDlqReprocessor], which moves each dead lettered message
+     * inside a channel transaction.
+     *
+     * The `@Primary` [RabbitTemplate] is not channel-transacted, and `CachingConnectionFactory` then
+     * hands out a channel whose proxy rejects `txSelect` with
+     * `UnsupportedOperationException: Cannot start transaction on non-transactional channel` — which
+     * made the drain fail on every instance. Only the reprocessor needs transacted channels, so it
+     * gets its own template rather than changing publish semantics for everything else.
+     */
+    @Bean("notification-dlq-rabbit-template")
+    fun notificationDlqRabbitTemplate(connectionFactory: ConnectionFactory): RabbitTemplate =
+        RabbitTemplate(connectionFactory).apply { isChannelTransacted = true }
+
     @Bean("notification-user-dlq-reprocessor")
     fun notificationUserDlqReprocessor(
         amqpAdmin: AmqpAdmin,
         @Qualifier("notification-user-notification-dlq") dlq: Queue,
-        rabbitTemplate: RabbitTemplate
+        @Qualifier("notification-dlq-rabbit-template") rabbitTemplate: RabbitTemplate
     ): NotificationDlqReprocessor = NotificationDlqReprocessor(amqpAdmin, dlq, rabbitTemplate)
 }

--- a/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationQueueConfigurationTest.kt
+++ b/application/aam-backend-service/src/test/kotlin/com/aamdigital/aambackendservice/notification/di/NotificationQueueConfigurationTest.kt
@@ -1,0 +1,64 @@
+package com.aamdigital.aambackendservice.notification.di
+
+import com.aamdigital.aambackendservice.notification.di.NotificationQueueConfiguration.Companion.USER_NOTIFICATION_DLQ
+import com.rabbitmq.client.Channel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.amqp.core.Queue
+import org.springframework.amqp.rabbit.connection.Connection
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+
+/**
+ * Guards the channel-transacted wiring of the dead letter drain.
+ *
+ * [com.aamdigital.aambackendservice.notification.queue.NotificationDlqReprocessor] moves each
+ * message inside a channel transaction, which only works on a channel obtained with
+ * `transactional = true`. Whether that happens is decided entirely by the `channelTransacted` flag
+ * on the [org.springframework.amqp.rabbit.core.RabbitTemplate] it is handed — nothing in the
+ * reprocessor itself can tell the difference, and its own unit tests mock the template away.
+ *
+ * Wired to the non-transacted `@Primary` template, every drain failed with
+ * `UnsupportedOperationException: Cannot start transaction on non-transactional channel`, once per
+ * process, across the whole fleet. This asserts the channel the drain actually asks for.
+ */
+class NotificationQueueConfigurationTest {
+    private val configuration = NotificationQueueConfiguration()
+
+    @Test
+    fun `asks for a transactional channel when draining the dead letter queue`() {
+        // Given - a connection factory that records which kind of channel is requested
+        val channel: Channel = mock()
+        val connection: Connection = mock()
+        val connectionFactory: ConnectionFactory = mock()
+        whenever(connectionFactory.createConnection()).thenReturn(connection)
+        whenever(connection.createChannel(any())).thenReturn(channel)
+        whenever(channel.isOpen).thenReturn(true)
+        whenever(channel.basicGet(any(), any())).thenReturn(null)
+
+        val reprocessor =
+            configuration.notificationUserDlqReprocessor(
+                amqpAdmin = mock(),
+                dlq = Queue(USER_NOTIFICATION_DLQ),
+                rabbitTemplate = configuration.notificationDlqRabbitTemplate(connectionFactory)
+            )
+
+        // When
+        reprocessor.reprocessDeadLetteredNotifications()
+
+        // Then - a non-transactional channel would reject txSelect and the drain would never run
+        verify(connection).createChannel(true)
+    }
+
+    @Test
+    fun `the dead letter template is channel-transacted`() {
+        // Given / When
+        val template = configuration.notificationDlqRabbitTemplate(mock())
+
+        // Then
+        assertThat(template.isChannelTransacted).isTrue()
+    }
+}


### PR DESCRIPTION
Closes #190

The DLQ reprocessor added in #177 has never completed a drain on any instance.

`drainDeadLetterQueue()` moves each message inside a channel transaction, but the bean was wired to the `@Primary` `RabbitTemplate`, which is not channel-transacted. `CachingConnectionFactory` then hands back a cached non-transactional channel whose proxy rejects `txSelect`, so every drain fails with:

```
UnsupportedOperationException: Cannot start transaction on non-transactional channel
  at jdk.proxy2.$Proxy211.txSelect(Unknown Source)
  at CachingConnectionFactory$CachedChannelInvocationHandler.invoke(CachingConnectionFactory.java:1133)
```

Observed on 22 production instances plus dev ([AAM-BACKEND-SERVICE-8X](https://aam-digital.sentry.io/issues/AAM-BACKEND-SERVICE-8X), 24 events since 19 Aug). Because `permanentFailureLogged` guards the error log, it surfaces exactly once per process and then goes quiet — dead lettered notifications are silently never re-queued, and the "fix the root cause and restart the service" recovery path the class documents is a no-op.

### Changes

- `NotificationQueueConfiguration` gains a dedicated `notification-dlq-rabbit-template` with `isChannelTransacted = true`, and the reprocessor bean takes it by qualifier. Only the reprocessor needs transacted channels, so the shared `@Primary` template — and every other producer's publish semantics — is left alone.
- New `NotificationQueueConfigurationTest` builds the reprocessor exactly as the configuration does, runs a drain against a recording `ConnectionFactory`, and asserts `createChannel(true)`.

### Verification

- `NotificationQueueConfigurationTest` (2) and `NotificationDlqReprocessorTest` (5) all pass.
- **Both new tests fail against the previous wiring** — reverting the flag to `false` gives `ArgumentsAreDifferent` on `createChannel(true)` and a failed `isChannelTransacted` assertion — so they genuinely guard the regression.
- `compileKotlin`, `compileTestKotlin`, and ktlint clean on both changed files (the repo's ktlint run has pre-existing violations elsewhere, untouched here).
- The two `CucumberTestRunner` failures in the local run are testcontainers needing a Docker daemon, unrelated to this change.

The existing `NotificationDlqReprocessorTest` could not have caught this: it mocks `RabbitTemplate` and stubs `execute` to invoke the callback against a mock `Channel`, so `txSelect()` always succeeds under test. The defect lived entirely in the wiring, which had no test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN11fEb2uzGKavSrtvYvth


---
_Generated by [Claude Code](https://claude.ai/code/session_01YN11fEb2uzGKavSrtvYvth)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dead-letter notification processing by using a dedicated transactional messaging channel.
  * Increased reliability when reprocessing failed notifications.

* **Tests**
  * Added coverage to verify dead-letter queue wiring and transactional channel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->