### PR TITLE
fix(logging): tag Sentry events with the release and upload source bundles

### DIFF
--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -146,7 +146,9 @@ jobs:
             APPLICATION_VERSION=${{ env.APPLICATION_VERSION }}
             SENTRY_UPLOAD_SOURCES=${{ github.event_name != 'pull_request' }}
           # Empty input rather than an empty value: `sentry_auth_token=` alone makes the action
-          # warn that it is not a valid secret.
+          # warn that it is not a valid secret. Keep this condition in sync with the one on
+          # SENTRY_UPLOAD_SOURCES above: a build that is told to upload but gets no token fails
+          # on purpose, rather than quietly skipping the upload.
           secrets: ${{ github.event_name != 'pull_request' && format('sentry_auth_token={0}', secrets.SENTRY_TOKEN) || '' }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}

--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -138,8 +138,15 @@ jobs:
           context: ./application/aam-backend-service
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
+          # SENTRY_UPLOAD_SOURCES lets the Gradle build inside the image upload this build's
+          # source bundle, so Sentry can show our source code next to the stack trace frames
+          # (see Dockerfile). Off for pull requests: those images are never deployed, and forks
+          # cannot read the secret anyway.
           build-args: |
             APPLICATION_VERSION=${{ env.APPLICATION_VERSION }}
+            SENTRY_UPLOAD_SOURCES=${{ github.event_name != 'pull_request' }}
+          secrets: |
+            sentry_auth_token=${{ github.event_name != 'pull_request' && secrets.SENTRY_TOKEN || '' }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}
           cache-to: type=gha,mode=min,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}

--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -145,8 +145,9 @@ jobs:
           build-args: |
             APPLICATION_VERSION=${{ env.APPLICATION_VERSION }}
             SENTRY_UPLOAD_SOURCES=${{ github.event_name != 'pull_request' }}
-          secrets: |
-            sentry_auth_token=${{ github.event_name != 'pull_request' && secrets.SENTRY_TOKEN || '' }}
+          # Empty input rather than an empty value: `sentry_auth_token=` alone makes the action
+          # warn that it is not a valid secret.
+          secrets: ${{ github.event_name != 'pull_request' && format('sentry_auth_token={0}', secrets.SENTRY_TOKEN) || '' }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}
           cache-to: type=gha,mode=min,url=${{ runner.env.ACTIONS_CACHE_URL }},token=${{ runner.env.ACTIONS_RUNTIME_TOKEN }}

--- a/application/aam-backend-service/Dockerfile
+++ b/application/aam-backend-service/Dockerfile
@@ -1,14 +1,18 @@
 FROM gradle:9.6.1-jdk21-alpine AS BUILD
 WORKDIR /opt/app
 COPY . .
-# When a Sentry auth token is mounted (see the build workflow), the sources of this build are
+# With a Sentry auth token mounted (see the build workflow), the sources of this build are
 # bundled and uploaded, so Sentry shows the surrounding source code for our own stack trace
 # frames. That has to happen in this Gradle run: the bundle id is generated once per build and
 # baked into the jar, so an upload from any other build would not match the shipped jar.
-# `installDist` alone does not pull the upload task in. Without a token (e.g. builds from
-# forks) only the plain build runs, exactly as before.
+# `installDist` alone does not pull the upload task in. Without a token (e.g. builds from forks)
+# only the plain build runs, exactly as before.
+# The build arg is what keeps this honest across the layer cache: secrets are deliberately not
+# part of the cache key, so without it a layer built without a token would be reused for a build
+# that has one - shipping a jar whose bundle id was never uploaded.
+ARG SENTRY_UPLOAD_SOURCES=false
 RUN --mount=type=secret,id=sentry_auth_token \
-    if [ -s /run/secrets/sentry_auth_token ]; then \
+    if [ "$SENTRY_UPLOAD_SOURCES" = "true" ] && [ -s /run/secrets/sentry_auth_token ]; then \
       SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" \
         gradle installDist sentryUploadSourceBundleJava; \
     else \

--- a/application/aam-backend-service/Dockerfile
+++ b/application/aam-backend-service/Dockerfile
@@ -1,18 +1,24 @@
 FROM gradle:9.6.1-jdk21-alpine AS BUILD
 WORKDIR /opt/app
 COPY . .
-# With a Sentry auth token mounted (see the build workflow), the sources of this build are
-# bundled and uploaded, so Sentry shows the surrounding source code for our own stack trace
-# frames. That has to happen in this Gradle run: the bundle id is generated once per build and
-# baked into the jar, so an upload from any other build would not match the shipped jar.
-# `installDist` alone does not pull the upload task in. Without a token (e.g. builds from forks)
-# only the plain build runs, exactly as before.
-# The build arg is what keeps this honest across the layer cache: secrets are deliberately not
-# part of the cache key, so without it a layer built without a token would be reused for a build
-# that has one - shipping a jar whose bundle id was never uploaded.
+# With SENTRY_UPLOAD_SOURCES=true the sources of this build are bundled and uploaded, so Sentry
+# shows the surrounding source code for our own stack trace frames (see the build workflow). That
+# has to happen in this Gradle run: the bundle id is generated once per build and baked into the
+# jar, so an upload from any other build would not match the shipped jar, and `installDist` alone
+# does not pull the upload task in.
+# The flag is a build arg rather than just "upload if a token is mounted", because secrets are
+# deliberately not part of the layer cache key: a layer built without a token would otherwise be
+# reused for a build that has one, shipping a jar whose bundle id was never uploaded. For the same
+# reason asking for an upload without a usable token is an error rather than a quiet fallback - a
+# missing upload should not pass unnoticed. Builds that don't ask for one (pull requests, forks)
+# run the plain build, exactly as before.
 ARG SENTRY_UPLOAD_SOURCES=false
 RUN --mount=type=secret,id=sentry_auth_token \
-    if [ "$SENTRY_UPLOAD_SOURCES" = "true" ] && [ -s /run/secrets/sentry_auth_token ]; then \
+    if [ "$SENTRY_UPLOAD_SOURCES" = "true" ]; then \
+      if [ ! -s /run/secrets/sentry_auth_token ]; then \
+        echo "SENTRY_UPLOAD_SOURCES=true but no sentry_auth_token secret is mounted" >&2; \
+        exit 1; \
+      fi; \
       SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" \
         gradle installDist sentryUploadSourceBundleJava; \
     else \

--- a/application/aam-backend-service/Dockerfile
+++ b/application/aam-backend-service/Dockerfile
@@ -1,7 +1,19 @@
 FROM gradle:9.6.1-jdk21-alpine AS BUILD
 WORKDIR /opt/app
 COPY . .
-RUN gradle installDist
+# When a Sentry auth token is mounted (see the build workflow), the sources of this build are
+# bundled and uploaded, so Sentry shows the surrounding source code for our own stack trace
+# frames. That has to happen in this Gradle run: the bundle id is generated once per build and
+# baked into the jar, so an upload from any other build would not match the shipped jar.
+# `installDist` alone does not pull the upload task in. Without a token (e.g. builds from
+# forks) only the plain build runs, exactly as before.
+RUN --mount=type=secret,id=sentry_auth_token \
+    if [ -s /run/secrets/sentry_auth_token ]; then \
+      SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)" \
+        gradle installDist sentryUploadSourceBundleJava; \
+    else \
+      gradle installDist; \
+    fi
 
 # Pinned to a full JDK patch version on purpose. The floating "21-alpine" tag never changes,
 # so Renovate had nothing to update and a JDK security fix produced no signal at all — the
@@ -12,7 +24,7 @@ WORKDIR /opt/app
 COPY --from=BUILD /opt/app/build/install/aam-backend-service /opt/app
 # Consumed at runtime as sentry.release (see application.yaml) so error events are tagged with a
 # version. Left empty rather than a placeholder like "unknown" when not passed at build time, so
-# Sentry falls back to no release instead of lumping unrelated builds under one fake release.
+# unrelated builds are not lumped together under one fake release.
 ARG APPLICATION_VERSION=
 ENV APPLICATION_VERSION=${APPLICATION_VERSION}
 EXPOSE 8080

--- a/application/aam-backend-service/build.gradle.kts
+++ b/application/aam-backend-service/build.gradle.kts
@@ -124,8 +124,8 @@ sentry {
 
     org = "aam-digital"
     projectName = "aam-backend-service"
+    // Set in the Docker build from a mounted secret; without it the upload is skipped.
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
-    version = System.getenv("APPLICATION_VERSION")
 }
 
 kotlin {

--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -119,6 +119,13 @@ logging:
 application:
   base-url: "" # default for backwards compatibility - this should be set in env however!
 
+sentry:
+  # Version of the running build, baked into the image from the APPLICATION_VERSION build arg
+  # (see Dockerfile), so error events are tagged with a release. This has to stay in the
+  # always-active part of the config: the "local-development" document below is skipped in
+  # production, where no Spring profile is active.
+  release: ${APPLICATION_VERSION:}
+
 ---
 # <second part of the config, just active with profile "local-development">
 
@@ -238,7 +245,6 @@ crypto-configuration:
 sentry:
   logging:
     enabled: false
-  release: ${APPLICATION_VERSION:#{null}}
 
 application:
   base-url: https://aam.localhost


### PR DESCRIPTION
## Why

Two Sentry settings for this service looked configured but never took effect on deployed instances.

**No release on events.** `sentry.release` (added in #179) sits in the second document of `application.yaml`, which is gated by `spring.config.activate.on-profile: local-development`. Production runs with no active profile — the event context confirms it (`spring.active_profiles: []`) — so the property was never applied. Every event since then arrived without a release, even though the image does carry the version in `APPLICATION_VERSION`. The Sentry project has no release recorded at all, while a running instance is demonstrably on a version that contains the change.

**No source context.** `includeSourceContext = true` generates a bundle id and bakes it into the jar — events already carry it as `debug_meta` — but the matching sources were never uploaded. `gradle installDist` (what the Dockerfile runs) does not pull in `sentryUploadSourceBundleJava`, and no auth token reached the build stage.

## What changed

- **release**: moved into the always-active first document. `sentry.logging.enabled` deliberately stays local-development-only, since instances turn it on through `SENTRY_LOGGING_ENABLED`. The `#{null}` default went with it: SpEL is not evaluated when binding `@ConfigurationProperties`, so without the variable the release became the literal string `#{null}` rather than no release.
- **source context**: the Gradle build inside the image now also runs `sentryUploadSourceBundleJava`, with the token passed as a BuildKit secret (so it stays out of the image and its metadata) for non-PR builds. It has to be the same Gradle run that produces the jar, because the bundle id is generated once per build. The `SENTRY_UPLOAD_SOURCES` build arg keeps the layer cache from reusing a token-less layer for a build that should upload — secrets are deliberately not part of the cache key, and without the arg the upload is silently skipped.
- dropped `version = System.getenv("APPLICATION_VERSION")` from the `sentry` block: `SentryPluginExtension` has no `version` property, so Kotlin resolved it against the outer `Project` and set the project version to null — the shipped jar was `aam-backend-service-plain.jar`, with the declared `0.0.1-SNAPSHOT` silently dropped.

## Verified

Against the published `v1.22.9` image, running Sentry's Spring Boot auto-configuration on the app's own classpath with the DSN pointed at a local sink:

- before: `sentry.release` resolves to `null` with no profile, `v1.22.9` with `local-development` — the bug
- after: `v1.22.9` in both cases, and the captured envelope carries `"release":"v1.22.9"`
- events already contain `debug_meta {type: jvm, debug_id: …}`, so only the upload half was missing
- image build stage builds green with `SENTRY_UPLOAD_SOURCES` off; with it on and a dummy token the upload task runs and fails on the invalid token, i.e. it is wired now (the plugin's bundled sentry-cli is statically linked, so it runs in the Alpine build image)

## Note

The upload uses the org `SENTRY_TOKEN` secret. If it lacks permission to upload debug files, the first non-PR image build will fail with `An API request has failed due to an invalid token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved error monitoring by associating production releases with the application version.
  * Enabled source information uploads for eligible production builds, providing more detailed debugging information in Sentry.
  * Prevented pull-request builds from publishing source information or affecting production monitoring releases.
  * Strengthened source upload validation to ensure monitoring data is published only when properly configured.
  * Clarified release grouping so unrelated builds are not combined under the same Sentry release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->