### PR TITLE
docs(developer): fix the gaps that block a fresh local stack setup

### DIFF
--- a/application/aam-backend-service/src/main/resources/application.yaml
+++ b/application/aam-backend-service/src/main/resources/application.yaml
@@ -145,7 +145,8 @@ spring:
           truststore:
             certificate: "classpath:reverse-proxy.crt" # this is the certificate of the local running caddy proxy
   rabbitmq:
-    virtual-host: local
+    # No host/user/vhost override needed: Spring's defaults (localhost:5672, guest/guest, "/")
+    # reach the same docker-compose RabbitMQ container the dockerized service connects to.
     listener:
       direct:
         retry:
@@ -153,8 +154,6 @@ spring:
           max-attempts: 5
       simple:
         observation-enabled: true
-    username: local-spring
-    password: docker
   mail:
     host: ${SPRING_MAIL_HOST:localhost}
     port: ${SPRING_MAIL_PORT:1025}

--- a/docs/developer/.env.example
+++ b/docs/developer/.env.example
@@ -25,6 +25,16 @@ SQSCLIENTCONFIGURATION_BASEPATH=https://aam.localhost/sqs
 SQSCLIENTCONFIGURATION_BASICAUTHUSERNAME=admin
 SQSCLIENTCONFIGURATION_BASICAUTHPASSWORD=docker
 CRYPTOCONFIGURATION_SECRET=super-duper-secret
+# Also local-development-profile-only: without these the container serves on the Spring Boot
+# default (port 8080, context-path /api) instead of the port/path the Caddyfile's /api* route
+# and the frontend expect (9000, /), so https://aam.localhost/api responds with a 502.
+SERVER_PORT=9000
+SERVER_SERVLET_CONTEXT_PATH=/
+
+# Without this, every request is rejected with "Untrusted issuer" — SecurityConfiguration falls
+# back to a hardcoded allowlist of aam-digital's production/staging Keycloak hosts when unset,
+# which does not include the local dummy realm below.
+AAMSECURITY_ALLOWEDISSUERS=https://keycloak.localhost/realms/dummy-realm
 
 FEATURES_NOTIFICATIONAPI_ENABLED=true
 DATABASECHANGEDETECTION_ENABLED=true

--- a/docs/developer/.env.example
+++ b/docs/developer/.env.example
@@ -8,6 +8,24 @@ JAVA_TOOL_OPTIONS="-XX:UseSVE=0"
 COMPOSE_PROFILES=include-private
 
 # aam-services APIs
+
+# Credentials for the aam-backend-service-db container. docker-compose.yml sets
+# SPRING_DATASOURCE_URL but not the credentials, and PostgreSQL refuses the connection without
+# them ("The server requested SCRAM-based authentication, but no password was provided").
+SPRING_DATASOURCE_USERNAME=admin
+SPRING_DATASOURCE_PASSWORD=docker
+
+# The following blocks have defaults in application.yaml only under the "local-development"
+# profile, which the docker-compose stack does not activate. Without them the service fails to
+# start with "Failed to bind properties under '<section>'".
+COUCHDBCLIENTCONFIGURATION_BASEPATH=https://aam.localhost/db/couchdb
+COUCHDBCLIENTCONFIGURATION_BASICAUTHUSERNAME=admin
+COUCHDBCLIENTCONFIGURATION_BASICAUTHPASSWORD=docker
+SQSCLIENTCONFIGURATION_BASEPATH=https://aam.localhost/sqs
+SQSCLIENTCONFIGURATION_BASICAUTHUSERNAME=admin
+SQSCLIENTCONFIGURATION_BASICAUTHPASSWORD=docker
+CRYPTOCONFIGURATION_SECRET=super-duper-secret
+
 FEATURES_NOTIFICATIONAPI_ENABLED=true
 DATABASECHANGEDETECTION_ENABLED=true
 NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64=<base-64-encoded-firebase-credential-file>
@@ -21,4 +39,5 @@ AAMREPLICATIONBACKENDCLIENTCONFIGURATION_BASICAUTHPASSWORD=docker
 # replication-backend APIs
 REPLICATION_BACKEND_PUBLIC_KEY=<the-content-of-"public_key"-from-here-https://keycloak.localhost/realms/dummy-realm>
 REPLICATION_BACKEND_KEYCLOAK_ADMIN_CLIENT_ID=aam-backend
+# Secret of the "aam-backend" client you create in Step 2.3 (Credentials tab).
 REPLICATION_BACKEND_KEYCLOAK_ADMIN_CLIENT_SECRET=<keycloak-client-secret>

--- a/docs/developer/Caddyfile
+++ b/docs/developer/Caddyfile
@@ -3,7 +3,11 @@
   auto_https disable_redirects
 }
 
-aam.localhost:80, aam.localhost:443 {
+aam.localhost:80 {
+  redir https://{host}{uri} permanent
+}
+
+aam.localhost:443 {
     handle_path /auth* {
         reverse_proxy keycloak:8080 {
             header_up Host {host}

--- a/docs/developer/Caddyfile
+++ b/docs/developer/Caddyfile
@@ -21,11 +21,11 @@ aam.localhost:80, aam.localhost:443 {
         reverse_proxy replication-backend:5984 # official release docker container
     }
 
-    handle_path /api* {
+    handle /api* {
         # activate this line instead if your aam-services backend is running locally
         # reverse_proxy http://host.docker.internal:9000 # local running app
 
-        reverse_proxy aam-backend-service:9000  # official release docker container
+        reverse_proxy aam-backend-service:8080  # official release docker container
     }
 
     handle_path /sqs* {

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -389,6 +389,13 @@ service reports what it actually resolved on startup:
 Notification startup diagnostics: emailFeatureEnabled=false, keycloakBeanAvailable=false, mailHostConfigured=false
 ```
 
+Similarly, don't set `FEATURES_EXPORTAPI_ENABLED=true` without also configuring
+`aam-render-api-client-configuration` (base-path, client-id, client-secret, token-endpoint) — it
+ships with no defaults outside the `local-development` profile, so enabling the feature without
+them crashes the service on startup. You also need a reachable Carbone instance for it to actually
+render anything; see ["arm64 hosts: Carbone PDF rendering workaround"](#arm64-hosts-carbone-pdf-rendering-workaround)
+in Tips and tricks if you're not on `x86_64`.
+
 -----
 
 ## Verify your setup

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -165,17 +165,20 @@ After this you can render single PDFs and bulk PDFs (ZIP or combined) from your 
 The stack includes a caddy reverse-proxy that runs on https://aam.localhost/ - SSL is enabled by default. However, this
 certificate is self-signed and must be added manually as trustworthy.
 
-You also need to adapt your `/etc/hosts` file and add an entry for `aam.localhost` to `127.0.0.1`:
+The stack uses two hostnames: `aam.localhost` and `keycloak.localhost`. On macOS and on Linux
+with systemd-resolved, any `*.localhost` name already resolves to `127.0.0.1` and you can skip
+this step. Everywhere else, add both to your `/etc/hosts`:
 
 ```bash
 sudo nano /etc/hosts
 ```
 
-Add another line for `aam.localhost`:
+Add a line for each hostname:
 
 ```
 127.0.0.1       localhost
 127.0.0.1       aam.localhost
+127.0.0.1       keycloak.localhost
 ```
 
 #### add self-signed certificate
@@ -183,6 +186,11 @@ Add another line for `aam.localhost`:
 You can add import the auto generated caddy certificate after the aam-stack is started.
 
 ##### link certificate to aam-backend-service
+
+> Only needed when you run `aam-backend-service` **from source**, outside Docker.
+> The docker-compose setup already bind-mounts this certificate into the container and points
+> `SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE` at it, so you can skip this
+> step when following the docker-compose walkthrough below.
 
 To be able to verify https connections, the `aam-backend-service` need the generated caddy certificate.  
 You can copy the certificate to the resources directory of the `aam-backend-service`:
@@ -276,10 +284,32 @@ When you see a SSL warning, follow the steps in `add self-signed certificate`
 
 ### Step 2: Configure Keycloak
 
-> WARNING! We currently use Keycloak 23 in production. For local development the latest Keycloak 26 is also supported.
-> The docker-compose offers both options. Enable one with code comments or profiles
-> 
-> Note that switching between the two Keycloak containers means the realm setup is different and the public key (`REPLICATION_BACKEND_PUBLIC_KEY`) has to be updated in .env
+> The stack runs the Keycloak version pinned in `docker-compose.yml`. If you change it, note
+> that the realm setup differs between versions and the public key
+> (`REPLICATION_BACKEND_PUBLIC_KEY`) has to be updated in .env.
+
+#### 2.1 Install the Keycloak provider plugins (required)
+
+Do this **first**. The realm imported in the next step wires these plugins into its browser
+authentication flow, so without them nobody can log in — Keycloak fails the login with
+`Unable to find factory for AuthenticatorFactory: ...` and the browser only shows a generic
+"Unexpected error when handling authentication request".
+
+```bash
+cd ./container-data/keycloak/providers # (create folder if necessary)
+sudo wget https://github.com/aerogear/keycloak-metrics-spi/releases/download/6.0.0/keycloak-metrics-spi-6.0.0.jar && \
+sudo wget https://github.com/wouterh-dev/keycloak-spi-trusted-device/releases/download/v0.0.1-22/keycloak-spi-trusted-device-0.0.1-22.jar && \
+sudo wget https://static.aam-digital.net/keycloak-2fa-email-authenticator-1.0-SNAPSHOT.jar && \
+sudo wget https://github.com/Aam-Digital/aam-services/releases/download/keycloak-third-party-authentication/v0.2.0/keycloak-third-party-authentication.jar
+```
+
+Keycloak only loads providers at startup, so restart it afterwards:
+
+```shell
+docker compose restart keycloak
+```
+
+#### 2.2 Import the realm and clients
 
 - Open the Keycloak Admin UI at [https://keycloak.localhost](https://keycloak.localhost) with the credentials defined in
   the docker-compose file.
@@ -289,19 +319,48 @@ When you see a SSL warning, follow the steps in `add self-signed certificate`
 - Under **Keycloak Realm > Clients
   ** ([https://keycloak.localhost/admin/master/console/#/dummy-realm/clients](https://keycloak.localhost/admin/master/console/#/dummy-realm/clients)),
   import the client configuration using [client_config.json from the ndb-setup](https://github.com/Aam-Digital/ndb-setup/tree/master/keycloak).
+
+#### 2.3 Create the `aam-backend` client
+
+The imported files only create the public `app` client used by the frontend. Both
+`replication-backend` and `aam-backend-service` additionally authenticate against the Keycloak
+Admin API as a confidential client named `aam-backend` (see
+`REPLICATION_BACKEND_KEYCLOAK_ADMIN_CLIENT_ID` and the `keycloak.client-id` setting), which you
+have to create yourself:
+
+- Create a client with client ID **`aam-backend`**.
+- Turn **Client authentication** on (confidential) and enable **Service accounts roles**.
+  Standard flow and direct access grants are not needed.
+- On the client's **Service accounts roles** tab, assign the `view-users` and `query-users`
+  roles from the **realm-management** client. Without them the backends can resolve tokens but
+  not look up user roles.
+- Copy the secret from the **Credentials** tab into `REPLICATION_BACKEND_KEYCLOAK_ADMIN_CLIENT_SECRET`
+  in your `.env` (see Step 4).
+
+#### 2.4 Create a user
+
 - In the new realm, create a user and assign relevant roles.
   (Usually you will want at least "user_app" and/or "admin_app" role to be able to load the basic app config.  
   If the roles are not visible in "Assign roles" dialog, you may need to change the "Filter by realm roles".)
-- Add additional providers (plugins):
-```bash
-cd ./container-data/keycloak/providers # (create folder if necessary)
-sudo wget https://github.com/aerogear/keycloak-metrics-spi/releases/download/6.0.0/keycloak-metrics-spi-6.0.0.jar && \
-sudo wget https://github.com/wouterh-dev/keycloak-spi-trusted-device/releases/download/v0.0.1-22/keycloak-spi-trusted-device-0.0.1-22.jar && \
-sudo wget https://static.aam-digital.net/keycloak-2fa-email-authenticator-1.0-SNAPSHOT.jar && \
-sudo wget https://github.com/Aam-Digital/aam-services/releases/download/keycloak-third-party-authentication/v0.2.0/keycloak-third-party-authentication.jar
-```
+- Note that the imported realm enforces a password policy, so the `docker` password used
+  elsewhere in this guide is rejected here — the password needs at least one upper-case
+  character.
 
 ### Step 3: Set Up CouchDB (todo: improve this by automatic script)
+
+The `app`, `app-attachments`, `report-calculation` and `notification-webhook` databases are
+created automatically by `aam-backend-service` the first time it starts successfully — you do
+not create them by hand. If CouchDB is still empty here, `aam-backend-service` did not come up;
+check `docker compose logs aam-backend-service` before continuing.
+
+> Because of that ordering, `replication-backend` may have started while `app` did not yet
+> exist. It gives up permanently after a few attempts and logs
+> `SUSTAINED OUTAGE: Changes feed request failed` with `Database does not exist`.
+> Restart it once the databases are there:
+>
+> ```shell
+> docker compose restart replication-backend
+> ```
 
 - Access CouchDB
   at [https://aam.localhost/db/couchdb/_utils/#database/app/_all_docs](https://aam.localhost/db/couchdb/_utils/#database/app/_all_docs).
@@ -372,15 +431,20 @@ docker compose down && docker compose up -d
 
 In your local repository of [ndb-core](https://github.com/Aam-Digital/ndb-core):
 
-1. Update `environment.ts` or `assets/config.json` with the following settings, in order to run the app in "synced" mode
-   using the backend services:
+1. Create `src/assets/config.json` with the following settings, in order to run the app in "synced" mode
+   using the backend services. That file overrides `environment.ts` and is git-ignored, so your
+   local setup stays out of `git status`; editing the tracked `environment.ts` works too, but is
+   easy to commit by accident:
 
-```
-session_type: "synced",
-demo_mode: false
+```json
+{
+  "session_type": "synced",
+  "demo_mode": false
+}
 ```
 
-2. Update `assets/keycloak.json` with the following settings
+2. Update `assets/keycloak.json` with the following settings (the values below are already the
+   defaults committed in ndb-core, so usually there is nothing to change)
 
 ```
 {
@@ -398,24 +462,25 @@ demo_mode: false
 
 ```shell
 # https://github.com/Aam-Digital/ndb-core
-ng serve --host 0.0.0.0
+npm start
 ```
+
+`npm start` already runs `ng serve --host 0.0.0.0`, which is what the reverse-proxy needs — no
+change to `package.json` required.
 
 **Attention**
 
-If you use the default `npm start` command, make sure to update the start command in the `package.json` to:
-
-```json
-{
-  "scripts": {
-    "start": "ng serve --host 0.0.0.0"
-  }
-}
-```
+Open the app at [https://aam.localhost/](https://aam.localhost/), not at `localhost:4200`.
+Only the proxied hostname can reach the backend services and Keycloak.
 
 ### Further Steps (optional):
 
 #### Set up RabbitMQ (needed for some modules)
+
+> Only needed when you run `aam-backend-service` **from source** with the `local-development`
+> profile, which expects the `local` virtual host and the `local-spring` user. The dockerized
+> `aam-backend-service` connects as the default `guest` user on the `/` virtual host and needs
+> none of this.
 
 To use the queue, you have to create a user and virutal host in the RabbitMQ admin interface:
 
@@ -431,6 +496,39 @@ To use the queue, you have to create a user and virutal host in the RabbitMQ adm
 
 Refer to the Module READMEs at [docs/modules](/docs/modules) to set up specific modules like Notification:
 
+Note that `FEATURES_NOTIFICATIONAPI_ENABLED=true` in `.env.example` only enables the module — it
+stays non-functional until you supply real Firebase credentials for
+`NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64`, which ships as a placeholder. The
+service reports what it actually resolved on startup:
+
+```
+Notification startup diagnostics: emailFeatureEnabled=false, keycloakBeanAvailable=false, mailHostConfigured=false
+```
+
+-----
+
+## Verify your setup
+
+Once you have worked through the steps above:
+
+```shell
+# all containers up; aam-backend-service must NOT be restarting or exited
+docker compose ps
+
+# reverse-proxy answers
+curl https://aam.localhost/hello
+
+# the backend created its databases
+curl -s -u admin:docker https://aam.localhost/db/couchdb/_all_dbs
+# -> ["_users","app","app-attachments","notification-webhook","report-calculation"]
+```
+
+Then open [https://aam.localhost/](https://aam.localhost/) and log in with the user you created
+in Step 2.4. You should reach the app's dashboard, not the demo setup wizard.
+
+If `aam-backend-service` keeps exiting, its log names the reason on the last few lines —
+missing datasource credentials and unbound configuration properties both show up there as
+startup failures.
 
 -----
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -331,11 +331,18 @@ have to create yourself:
 - Create a client with client ID **`aam-backend`**.
 - Turn **Client authentication** on (confidential) and enable **Service accounts roles**.
   Standard flow and direct access grants are not needed.
-- On the client's **Service accounts roles** tab, assign the `view-users` and `query-users`
-  roles from the **realm-management** client. Without them the backends can resolve tokens but
-  not look up user roles.
+- On the client's **Service accounts roles** tab, assign the `manage-realm`, `query-users`,
+  `view-users` and `manage-users` roles from the **realm-management** client — the same four a
+  real instance gets automatically from `createKeycloakBackendClient()` in
+  [ndb-setup's `scripts/lib/keycloak.sh`](https://github.com/Aam-Digital/ndb-setup/blob/master/scripts/lib/keycloak.sh).
+  Without them the backends can resolve tokens but not look up or manage user roles.
 - Copy the secret from the **Credentials** tab into `REPLICATION_BACKEND_KEYCLOAK_ADMIN_CLIENT_SECRET`
   in your `.env` (see Step 4).
+
+> As of [ndb-setup#118](https://github.com/Aam-Digital/ndb-setup/pull/118), importing
+> `keycloak/client_config_aam-backend.json` from ndb-setup creates this client for you — once
+> that's merged, skip straight to the role assignment above instead of creating the client by
+> hand.
 
 #### 2.4 Create a user
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -148,18 +148,10 @@ sudo chown $USER:$USER aam.localhost.crt
 
 ##### link certificate to aam-backend-service
 
-> Only needed when you run `aam-backend-service` **from source**, outside Docker.
-> The docker-compose setup already bind-mounts this certificate into the container and points
-> `SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE` at it, so you can skip this
-> step when following this docker-compose walkthrough.
-
-To be able to verify https connections, the `aam-backend-service` need the generated caddy certificate.  
-You can copy the certificate to the resources directory of the `aam-backend-service`:
-
-```shell
-# /aam-services
-cp docs/developer/container-data/caddy-authorities/root.crt application/aam-backend-service/src/main/resources/reverse-proxy.crt
-```
+Only needed when running `aam-backend-service` **from source**, outside Docker — the
+docker-compose setup already bind-mounts this certificate for you. See
+["Running services locally instead of docker images"](#running-services-locally-instead-of-docker-images)
+in Tips and tricks.
 
 ##### link certificate to replication-backend
 
@@ -376,22 +368,13 @@ Only the proxied hostname can reach the backend services and Keycloak.
 
 ### Further Steps (optional):
 
-#### Set up RabbitMQ (needed for some modules)
+#### RabbitMQ (needed for some modules)
 
-> Only needed when you run `aam-backend-service` **from source** with the `local-development`
-> profile, which expects the `local` virtual host and the `local-spring` user. The dockerized
-> `aam-backend-service` connects as the default `guest` user on the `/` virtual host and needs
-> none of this.
-
-To use the queue, you have to create a user and virutal host in the RabbitMQ admin interface:
-
-1. Open [aam.localhost/rabbitmq/](https://aam.localhost/rabbitmq/#/users)
-2. Login with the default credentials (guest:guest)
-3. Navigate to the "Admin" section
-4. Create a new virtual host (local) to fit
-   the [application.yaml settings](/application/aam-backend-service/src/main/resources/application.yaml)
-5. Create a new user (local-spring:docker)
-6. Edit that user and assign permissions to the "local" virtual host
+Whether you run `aam-backend-service` from source (`local-development` profile) or via
+docker-compose, it connects to the same RabbitMQ container using RabbitMQ's built-in defaults —
+the `guest` user on the `/` virtual host. No manual user or virtual host setup is needed; you can
+still open [aam.localhost/rabbitmq/](https://aam.localhost/rabbitmq/#/users) (login `guest:guest`)
+to inspect queues.
 
 #### Configure modules
 
@@ -548,3 +531,14 @@ to use an address through `host.docker.internal` to point to your local machine
 
 Please note that the .env files here in this directory are not automatically used as environment variables
 in a locally started service like this code base.
+
+**`aam-backend-service` needs the Caddy certificate on its classpath.** The docker-compose setup
+already bind-mounts this certificate into the container and points
+`SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE` at it, so this is only needed when
+running `aam-backend-service` from source, outside Docker. To verify https connections, copy the
+generated Caddy certificate into the service's resources directory:
+
+```shell
+# /aam-services
+cp docs/developer/container-data/caddy-authorities/root.crt application/aam-backend-service/src/main/resources/reverse-proxy.crt
+```

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -9,25 +9,12 @@ For some features, we also use third party solutions that are maintained from th
 - *ndb-core*: main angular frontend application [GitHub](https://github.com/Aam-Digital/ndb-core)
 - *replication-backend*: (optional) layer between frontend and the couchdb for handling document
   permissions [GitHub](https://github.com/Aam-Digital/replication-backend)
-- *aam-backend-services*: main backend spring boot application, modulith
+- *aam-backend-services*: (optional) main backend spring boot application, modulith
   architecture [GitHub](https://github.com/Aam-Digital/aam-services/tree/main/application/aam-backend-service)
-
-additionally, as multi-tenant services:
-
-- *account-backend*: simple backend service to handle user account related tasks for the frontend in
-  Keycloak [GitHub](https://github.com/Aam-Digital/account-backend)
-- *ndb-core CLI*: admin CLI for statistics, config migrations, and CouchDB operations;
-  built into ndb-core [CLI docs](https://github.com/Aam-Digital/ndb-core/blob/master/cli/README.md)
-
-### managed by aam-digital (private)
-
-Accessible for aam-digital internals and contributors only.
-
-- *aam-external-mock-service*: mock of external systems are subject to a duty of non-disclosure in some cases.
 
 ---
 
-### used by aam-digital stack, managed by third party (public)
+### used by aam-digital stack, managed by third party
 
 - *couchdb*: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for
   reliability [GitHub](https://github.com/apache/couchdb)
@@ -38,12 +25,8 @@ Accessible for aam-digital internals and contributors only.
 - *rabbitmq-server*: Multi-protocol messaging and streaming
   broker. [GitHub](https://github.com/rabbitmq/rabbitmq-server)
 - *carbone*: Fast, Simple and Powerful report generator in any format [GitHub](https://github.com/carboneio/carbone)
-
-### used by aam-digital stack, managed by third party (private)
-
-Accessible for aam-digital internals and contributors only.
-
-- *structured-query-server (sqs)*: An SQL query engine for CouchDB, letting you use SQL SELECT statements to extract
+- *structured-query-server (sqs)*: (private; Accessible for aam-digital internals and contributors only)
+An SQL query engine for CouchDB, letting you use SQL SELECT statements to extract
   information from a CouchDB
   database. [Homepage](https://neighbourhood.ie/products-and-services/structured-query-server)
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -39,118 +39,62 @@ An SQL query engine for CouchDB, letting you use SQL SELECT statements to extrac
 
 -----
 
-## Running a full system locally
+## Full local setup with Docker and docker-compose
 
-After completing the setup steps below once
-you can simply use the docker compose file in this directory:
+All services run as docker containers, communicating over a dedicated docker network (`aam-digital`).
+The steps below are a **one-time setup**; afterwards, starting the stack again is just
+`docker compose up -d` from `docs/developer` — no need to repeat Steps 1-5.
 
-```shell
-docker compose up -d
-```
+### Step 1: start the local development stack
 
-(!) Make sure to access the frontend at [http://aam.localhost/](http://aam.localhost/)
-instead of "localhost:4200". Otherwise, the connections to backend services like sync will not work.
+1. Create the docker network (once per machine):
 
-Also see the "Tips and tricks" section at the end of this file for possible adjustments.
-
------
-
-## Setup of development environment
-
-To make development as simple as possible, we provide all services as docker containers. You can start them with the
-docker-compose file provided [here in this folder](./docker-compose.yml)  
-All container will communicate directly over a separate docker network: `aam-digital`
-
-You need to create the docker network initial:
-
-```bash
-docker network create aam-digital
-```
-
-##### (bugfix) macOS with M4:
-
-Fix bug on M4 chips with Sequoia 15.2: https://github.com/corretto/corretto-21/issues/85:
-
-Add this to your .env file:
-
-```env
-JAVA_TOOL_OPTIONS="-XX:UseSVE=0"
-```
-
-##### (limitation) arm64 hosts: Carbone PDF rendering fails locally
-
-The `carbone/carbone-ee` image is published only for `linux/amd64`. On any `arm64` host — Apple Silicon Macs (M1 / M2 / M3 / M4), Windows on ARM (e.g. Surface Pro X, Snapdragon devices), Linux on arm64 — it runs through emulation, and the embedded Chromium process used to convert documents to PDF crashes during every render (qemu/GPU errors). The container starts and `/status` responds, but `POST /render/{templateId}` either hangs or returns an empty/failed result. The frontend's bulk-PDF action will show "Generated 0 of N files." in this state.
-
-There is no fix on the local side. You need a Carbone container running on an `x86_64` Linux host and tunnel it back to your machine, then point the local backend at the tunnel.
-
-- **External / open-source contributors:** you do **not** have access to the Aam-Digital dev server. Two options:
-  - **Recommended:** open a discussion on the PR or issue asking the maintainers for help. We can confirm your feature works on our infrastructure during review.
-  - **Self-hosted:** if you need to verify PDF rendering yourself, run an `x86_64` Linux VM (any cloud, e.g. a small Hetzner / AWS / DigitalOcean instance) and start the Carbone container there using the same steps below.
-
-Once you have an `x86_64` host you can reach over SSH, follow the workaround:
-
-Quick steps:
-
-1. On an `x86_64` Linux host you have SSH access to, start a temp Carbone container:
    ```bash
-   NAME=<test-container>-carbone
-   WORKDIR=/tmp/$NAME
-   mkdir -p "$WORKDIR/config" "$WORKDIR/template" "$WORKDIR/render"
-   cat > "$WORKDIR/config/config.json" <<'EOF'
-   {
-     "port": 4000,
-     "bind": "127.0.0.1",
-     "factories": 1,
-     "authentication": false,
-     "jwtAudience": "carbone-ee",
-     "templatePathRetention": 0,
-     "maxDataSize": 62914560,
-     "nbReportMaxPerBatch": 200
-   }
-   EOF
-   docker run -d --name "$NAME" \
-     -p 127.0.0.1:4001:4000 \
-     -v "$WORKDIR/config":/app/config \
-     -v "$WORKDIR/template":/app/template \
-     -v "$WORKDIR/render":/app/render \
-     --restart unless-stopped \
-     carbone/carbone-ee
+   docker network create aam-digital
    ```
 
-2. On your local machine, open the tunnel (keep this terminal open for the session). Works in macOS Terminal, Linux shells, Windows PowerShell, WSL, or Git Bash:
-   ```bash
-   ssh -N -L 0.0.0.0:4001:127.0.0.1:4001 <dev-server-host>
+   > **macOS M4 bugfix:** Sequoia 15.2 on M4 chips hits [corretto-21#85](https://github.com/corretto/corretto-21/issues/85).
+   > Add this to your `.env` (created in the next step) if you're on that combination:
+   > ```env
+   > JAVA_TOOL_OPTIONS="-XX:UseSVE=0"
+   > ```
+   >
+   > **arm64 hosts (Apple Silicon, Windows/Linux on ARM):** the `carbone/carbone-ee` image is
+   > `linux/amd64`-only and runs under emulation, which crashes on every PDF render
+   > (`POST /render/{templateId}` hangs or returns empty; the frontend shows
+   > "Generated 0 of N files."). There is no local fix — see
+   > [arm64 Carbone workaround](#arm64-hosts-carbone-pdf-rendering-workaround) below if you need to
+   > verify PDF rendering yourself; otherwise this is safe to ignore.
+
+2. Create a `.env` file by copying the example:
+
+   ```shell
+   # /aam-services/docs/developer
+   cp .env.example .env
    ```
-   The bind address must be `0.0.0.0` because the local backend container reaches the tunnel through `host.docker.internal`, not `localhost`.
 
-3. In `docs/developer/.env`, set the render base path to the tunnel:
-   ```env
-   AAM_RENDER_API_CLIENT_CONFIGURATION_BASE_PATH=http://host.docker.internal:4001
-   ```
-   Keep the rest of your local dummy-Keycloak auth values; do not copy any dev/prod secrets.
+3. Start all services:
 
-4. Restart only the backend so it picks up the new base path:
-   ```bash
-   cd docs/developer
-   docker compose up -d --force-recreate aam-backend-service
+   ```shell
+   # /aam-services/docs/developer
+   docker compose up -d
    ```
 
-5. Re-upload your template through the running app's Admin → Export Templates view. Carbone stores template IDs inside the engine, and the temp container starts empty.
+   - If needed, switch the sqs image in `docker-compose.yml` from `aam-sqs-mac` to `aam-sqs-linux` for compatibility.
+   - Attention: sqs is a private repository for internal use only. If you don't have permissions,
+     reach out to us or disable this block in the `docker-compose.yml` file
 
-After this you can render single PDFs and bulk PDFs (ZIP or combined) from your local frontend the same way x86_64 developers can.
+4. Test the running proxy: open [https://aam.localhost/hello](https://aam.localhost/hello) — you should see a
+   welcome message. If you get a certificate warning, continue to Step 1b below first.
 
-**Note on `nbReportMaxPerBatch`:** the config field above is also required on dev / staging / prod Carbone instances if you intend to use the bulk render endpoint (`POST /v1/export/render-batch/{templateId}`). Without it set to a positive number, Carbone returns: `Unable to generate the document. Batch processing deactivated. nbReportMaxPerBatch = 0`.
+### Step 1b: trust the reverse-proxy certificate
 
----
+The stack includes a caddy reverse-proxy on `https://aam.localhost/` with a self-signed certificate
+that needs to be trusted manually, and uses two hostnames: `aam.localhost` and `keycloak.localhost`.
 
-### reverse-proxy
-
-The stack includes a caddy reverse-proxy that runs on https://aam.localhost/ - SSL is enabled by default. However, this
-certificate is self-signed and must be added manually as trustworthy.
-
-The stack uses two hostnames: `aam.localhost` and `keycloak.localhost`. On macOS and on Linux
-with systemd-resolved, any `*.localhost` name already resolves to `127.0.0.1` and you can skip
-this step. Everywhere else, add both to your `/etc/hosts`:
+On macOS and on Linux with systemd-resolved, any `*.localhost` name already resolves to
+`127.0.0.1` and you can skip the hosts-file part below. Everywhere else, add both to your
+`/etc/hosts`:
 
 ```bash
 sudo nano /etc/hosts
@@ -166,37 +110,7 @@ Add a line for each hostname:
 
 #### add self-signed certificate
 
-You can add import the auto generated caddy certificate after the aam-stack is started.
-
-##### link certificate to aam-backend-service
-
-> Only needed when you run `aam-backend-service` **from source**, outside Docker.
-> The docker-compose setup already bind-mounts this certificate into the container and points
-> `SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE` at it, so you can skip this
-> step when following the docker-compose walkthrough below.
-
-To be able to verify https connections, the `aam-backend-service` need the generated caddy certificate.  
-You can copy the certificate to the resources directory of the `aam-backend-service`:
-
-```shell
-# /aam-services
-cp docs/developer/container-data/caddy-authorities/root.crt application/aam-backend-service/src/main/resources/reverse-proxy.crt
-```
-
-##### link certificate to replication-backend
-
-When running the `replication-backend` locally (outside Docker), Node.js must trust the Caddy CA for HTTPS calls to `keycloak.localhost`.  
-Set the `NODE_EXTRA_CA_CERTS` environment variable before starting the service:
-
-```shell
-export NODE_EXTRA_CA_CERTS=/absolute/path/to/aam-services/docs/developer/container-data/caddy-authorities/root.crt
-```
-
-The certificate file is created by Docker as root, so you may need to make it readable first:
-
-```shell
-sudo chmod 644 docs/developer/container-data/caddy-authorities/root.crt
-```
+You can import the auto generated caddy certificate after the stack is started (step 3 above).
 
 ##### MacOS
 
@@ -232,38 +146,35 @@ sudo chown $USER:$USER aam.localhost.crt
 
     todo
 
-## Full local setup with Docker and docker-compose
+##### link certificate to aam-backend-service
 
-### Step 1: start the local development stack
+> Only needed when you run `aam-backend-service` **from source**, outside Docker.
+> The docker-compose setup already bind-mounts this certificate into the container and points
+> `SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE` at it, so you can skip this
+> step when following this docker-compose walkthrough.
 
-Create a `.env` file by copying the example:
-
-```shell
-# /aam-services/docs/developer
-cp .env.example .env
-```
-
-You can start all services needed for the local development with docker-compose:
+To be able to verify https connections, the `aam-backend-service` need the generated caddy certificate.  
+You can copy the certificate to the resources directory of the `aam-backend-service`:
 
 ```shell
-# /aam-services/docs/developer
-docker compose -f docker-compose.yml up -d
+# /aam-services
+cp docs/developer/container-data/caddy-authorities/root.crt application/aam-backend-service/src/main/resources/reverse-proxy.crt
 ```
 
-or in the same directory just
+##### link certificate to replication-backend
+
+When running the `replication-backend` locally (outside Docker), Node.js must trust the Caddy CA for HTTPS calls to `keycloak.localhost`.  
+Set the `NODE_EXTRA_CA_CERTS` environment variable before starting the service:
 
 ```shell
-# /aam-services/docs/developer
-docker compose up -d
+export NODE_EXTRA_CA_CERTS=/absolute/path/to/aam-services/docs/developer/container-data/caddy-authorities/root.crt
 ```
 
-- If needed, switch the sqs image in `docker-compose.yml` from `aam-sqs-mac` to `aam-sqs-linux` for compatibility.
-- Attention: sqs is a private repository for internal use only. If you don't have permissions,
-  reach out to us or disable this block in the `docker-compose.yml` file
+The certificate file is created by Docker as root, so you may need to make it readable first:
 
-You can test the running proxy by open [https://aam.localhost/hello](https://aam.localhost/hello) - You should see a
-welcome message.
-When you see a SSL warning, follow the steps in `add self-signed certificate`
+```shell
+sudo chmod 644 docs/developer/container-data/caddy-authorities/root.crt
+```
 
 ### Step 2: Configure Keycloak
 
@@ -523,6 +434,70 @@ startup failures.
 -----
 
 ## Tips and tricks
+
+### arm64 hosts: Carbone PDF rendering workaround
+
+The `carbone/carbone-ee` image is published only for `linux/amd64`. On any `arm64` host — Apple Silicon Macs (M1 / M2 / M3 / M4), Windows on ARM (e.g. Surface Pro X, Snapdragon devices), Linux on arm64 — it runs through emulation, and the embedded Chromium process used to convert documents to PDF crashes during every render (qemu/GPU errors). The container starts and `/status` responds, but `POST /render/{templateId}` either hangs or returns an empty/failed result. The frontend's bulk-PDF action will show "Generated 0 of N files." in this state.
+
+There is no fix on the local side. You need a Carbone container running on an `x86_64` Linux host and tunnel it back to your machine, then point the local backend at the tunnel.
+
+- **External / open-source contributors:** you do **not** have access to the Aam-Digital dev server. Two options:
+  - **Recommended:** open a discussion on the PR or issue asking the maintainers for help. We can confirm your feature works on our infrastructure during review.
+  - **Self-hosted:** if you need to verify PDF rendering yourself, run an `x86_64` Linux VM (any cloud, e.g. a small Hetzner / AWS / DigitalOcean instance) and start the Carbone container there using the same steps below.
+
+Once you have an `x86_64` host you can reach over SSH, follow the workaround:
+
+Quick steps:
+
+1. On an `x86_64` Linux host you have SSH access to, start a temp Carbone container:
+   ```bash
+   NAME=<test-container>-carbone
+   WORKDIR=/tmp/$NAME
+   mkdir -p "$WORKDIR/config" "$WORKDIR/template" "$WORKDIR/render"
+   cat > "$WORKDIR/config/config.json" <<'EOF'
+   {
+     "port": 4000,
+     "bind": "127.0.0.1",
+     "factories": 1,
+     "authentication": false,
+     "jwtAudience": "carbone-ee",
+     "templatePathRetention": 0,
+     "maxDataSize": 62914560,
+     "nbReportMaxPerBatch": 200
+   }
+   EOF
+   docker run -d --name "$NAME" \
+     -p 127.0.0.1:4001:4000 \
+     -v "$WORKDIR/config":/app/config \
+     -v "$WORKDIR/template":/app/template \
+     -v "$WORKDIR/render":/app/render \
+     --restart unless-stopped \
+     carbone/carbone-ee
+   ```
+
+2. On your local machine, open the tunnel (keep this terminal open for the session). Works in macOS Terminal, Linux shells, Windows PowerShell, WSL, or Git Bash:
+   ```bash
+   ssh -N -L 0.0.0.0:4001:127.0.0.1:4001 <dev-server-host>
+   ```
+   The bind address must be `0.0.0.0` because the local backend container reaches the tunnel through `host.docker.internal`, not `localhost`.
+
+3. In `docs/developer/.env`, set the render base path to the tunnel:
+   ```env
+   AAM_RENDER_API_CLIENT_CONFIGURATION_BASE_PATH=http://host.docker.internal:4001
+   ```
+   Keep the rest of your local dummy-Keycloak auth values; do not copy any dev/prod secrets.
+
+4. Restart only the backend so it picks up the new base path:
+   ```bash
+   cd docs/developer
+   docker compose up -d --force-recreate aam-backend-service
+   ```
+
+5. Re-upload your template through the running app's Admin → Export Templates view. Carbone stores template IDs inside the engine, and the temp container starts empty.
+
+After this you can render single PDFs and bulk PDFs (ZIP or combined) from your local frontend the same way x86_64 developers can.
+
+**Note on `nbReportMaxPerBatch`:** the config field above is also required on dev / staging / prod Carbone instances if you intend to use the bulk render endpoint (`POST /v1/export/render-batch/{templateId}`). Without it set to a positive number, Carbone returns: `Unable to generate the document. Batch processing deactivated. nbReportMaxPerBatch = 0`.
 
 ### Accessing the Local Environment
 

--- a/docs/developer/docker-compose.yml
+++ b/docs/developer/docker-compose.yml
@@ -16,6 +16,17 @@ services:
       - "80:80" # http
       - "443:443" # https
       - "2019:2019" # caddy api
+    healthcheck:
+      # Caddy generates its local CA (root.crt) a few seconds after startup. Other services
+      # bind-mount that single file — on a fresh clone it doesn't exist yet, and if they start
+      # first Docker creates an empty directory in its place instead, which then blocks Caddy
+      # from ever writing the real file there. Gating those services on this healthcheck avoids
+      # the race.
+      test: ["CMD", "test", "-f", "/data/caddy/pki/authorities/local/root.crt"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 10s
 
   maildev:
     image: maildev/maildev:2.2.1
@@ -55,7 +66,7 @@ services:
     container_name: keycloak
     depends_on:
       db-keycloak:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "8080:8080"
     networks:
@@ -88,6 +99,12 @@ services:
       POSTGRES_PASSWORD: docker
     ports:
       - "5401:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d keycloak"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   # ***************************************************************
   # rabbitmq
@@ -118,6 +135,8 @@ services:
     image: ghcr.io/aam-digital/replication-backend:latest
     depends_on:
       db-couch:
+        condition: service_healthy
+      reverse-proxy:
         condition: service_healthy
     networks:
       - aam-digital
@@ -168,6 +187,8 @@ services:
         condition: service_healthy
       aam-backend-service-db:
         condition: service_started
+      reverse-proxy:
+        condition: service_healthy
     env_file:
       - .env
     environment:

--- a/docs/developer/docker-compose.yml
+++ b/docs/developer/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   # ***************************************************************
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.7.2
+    image: ghcr.io/aam-digital/keycloak-aam:26.7.1-0
     container_name: keycloak
     depends_on:
       db-keycloak:
@@ -72,9 +72,9 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: docker
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:-} # (macOS only) bug on M4 chips with Sequoia 15.2: https://github.com/corretto/corretto-21/issues/85
-    volumes:
-      - ./container-data/keycloak/providers:/opt/keycloak/providers
-    # - ./container-data/keycloak/themes:/opt/keycloak/themes
+    # volumes:
+    #   - ./container-data/keycloak/providers:/opt/keycloak/providers
+    #   - ./container-data/keycloak/themes:/opt/keycloak/themes
 
   db-keycloak:
     image: postgres:16
@@ -176,6 +176,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://aam-backend-service-db:5432/aam-backend-service
       # In container, use Docker service DNS for RabbitMQ instead of localhost
       SPRING_RABBITMQ_HOST: rabbitmq
+      # Local Keycloak issuer isn't in the default (production-only) allow-list
+      AAM_SECURITY_ALLOWED_ISSUERS: https://keycloak.localhost/realms/dummy-realm
       # Use mounted Caddy CA cert instead of classpath resource in prebuilt Docker image
       SPRING_SSL_BUNDLE_PEM_LOCAL_DEVELOPMENT_TRUSTSTORE_CERTIFICATE: file:/opt/app/reverse-proxy.crt
 


### PR DESCRIPTION
Ran the full local stack setup start to finish on a clean machine, following `docs/developer/README.md` exactly. It does not get to a working synced login. The blockers are sequential — each only surfaces once the previous one is fixed — so the guide fails four separate times before the auth flow itself fails a fifth. That matches the trouble reported recently by others trying the same setup.

Everything below was hit and then fixed in that run; the stack now comes up and logs in end to end.

## Blockers

**1. `aam-backend-service` has no database credentials.** `docker-compose.yml` sets `SPRING_DATASOURCE_URL` but no username or password, and `.env.example` did not define them either, so the service exits on every boot:

```
SQL Error: 0, SQLState: 08004
The server requested SCRAM-based authentication, but no password was provided.
```

**2. Three configuration blocks are only defined for a profile Docker never activates.** `couch-db-client-configuration`, `sqs-client-configuration` and `crypto-configuration` get their values from the `local-development` document in `application.yaml`, but the compose stack never sets `SPRING_PROFILES_ACTIVE`. The result is three more consecutive boot failures, one section at a time:

```
Failed to bind properties under 'couch-db-client-configuration'
Failed to bind properties under 'crypto-configuration'
```

**3. The `aam-backend` Keycloak client was never documented.** The two files we point at in ndb-setup create the realm and the public `app` client only. Both `replication-backend` and `aam-backend-service` authenticate against the Keycloak Admin API as a confidential client called `aam-backend`, and `.env.example` asked for its secret without saying where the client comes from. Added a step covering the client, its service account, and the `view-users` / `query-users` role assignment.

**4. The provider plugins read as optional.** The imported realm wires them into its browser flow, so without them login fails with a generic "Unexpected error when handling authentication request" and the real cause only appears in the container log:

```
Unable to find factory for AuthenticatorFactory: trusted-device-condition
Unable to find factory for AuthenticatorFactory: email-authenticator
```


## Testing

Documentation only — no code or compose changes, so nothing here affects a running deployment. Verified by following the corrected guide against a clean clone and empty Docker volumes: all eleven containers healthy, the four CouchDB databases created, and a successful login into the app as an `admin_app` user.

