### PR TITLE
chore(ci): stop concurrent main pushes from racing to create the same release

### DIFF
--- a/.github/workflows/aam-backend-service-build-and-publish.yml
+++ b/.github/workflows/aam-backend-service-build-and-publish.yml
@@ -221,9 +221,20 @@ jobs:
   publish:
     name: Publish aam-backend-service Release
     runs-on: ubuntu-latest
-    if: ${{ github.event.ref  != '' }} # release
+    # Only main pushes compute and create the next release; the tag push this job creates
+    # re-triggers this workflow (to build the version-tagged image in the build/merge jobs
+    # above) but must not re-run this job, or it wastes the concurrency slot below re-doing
+    # a no-op release computation.
+    if: ${{ github.ref == 'refs/heads/main' }} # release
     needs:
       - test
+    # Serializes releases across overlapping main-branch pushes (e.g. several PRs merged
+    # within minutes of each other). Without this, two runs can both read the same
+    # last-released tag before either creates the next one and race to create the same
+    # release, so the second's `gh api` call 422s on "already_exists".
+    concurrency:
+      group: aam-backend-service-publish
+      cancel-in-progress: false
     permissions:
       contents: write # to be able to publish a GitHub release
     defaults:
@@ -275,7 +286,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/Aam-Digital/aam-services/releases \
             -f "tag_name=$TAG_NAME" \
-            -f "target_commitish=main" \
+            -f "target_commitish=${{ github.sha }}" \
             -f "name=$TAG_NAME" \
             -F "draft=false" \
             -F "prerelease=false" \

--- a/.github/workflows/keycloak-third-party-authentication-build-and-publish.yml
+++ b/.github/workflows/keycloak-third-party-authentication-build-and-publish.yml
@@ -80,9 +80,20 @@ jobs:
   publish:
     name: Publish keycloak-third-party-authentication Release
     runs-on: ubuntu-latest
-    if: ${{ github.event.ref  != '' }} # release
+    # Only main pushes compute and create the next release; the tag push this job creates
+    # re-triggers this workflow (to build the versioned artifact in the build job above)
+    # but must not re-run this job, or it wastes the concurrency slot below re-doing a
+    # no-op release computation.
+    if: ${{ github.ref == 'refs/heads/main' }} # release
     needs:
       - build
+    # Serializes releases across overlapping main-branch pushes (e.g. several PRs merged
+    # within minutes of each other). Without this, two runs can both read the same
+    # last-released tag before either creates the next one and race to create the same
+    # release.
+    concurrency:
+      group: keycloak-third-party-authentication-publish
+      cancel-in-progress: false
     permissions:
       contents: write # to be able to publish a GitHub release
     defaults:
@@ -134,5 +145,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           TAG_NAME=keycloak-third-party-authentication/${{ env.NEXT_VERSION }}
-          gh release create "$TAG_NAME" --generate-notes
-          gh release upload "$TAG_NAME" keycloak-third-party-authentication.jar 
+          gh release create "$TAG_NAME" --target "${{ github.sha }}" --generate-notes
+          gh release upload "$TAG_NAME" keycloak-third-party-authentication.jar


### PR DESCRIPTION
Several PRs merging to main within minutes of each other let their publish jobs' `git describe` all read the same last-released tag before any of them had created the next one, so they computed the same next version and raced to create it — the losers hit HTTP 422 "already_exists" (e.g. run 34097505024 and 34097485841 both tried to create aam-backend-service/v1.22.12 after run 34097382624 already had).

A job-level concurrency group now serializes the publish job across overlapping runs, restricted to main pushes only (not the tag push it creates) so the lock isn't held needlessly by a run that can't produce a release anyway.

Also stopped pinning the release to the floating `main` ref/branch default: target_commitish now uses the run's own commit SHA. With target_commitish=main, v1.22.12 ended up tagging b7aa27f (#198) instead of b0ae08a (#200), the commit whose conventional-commit range actually produced that version bump — three merges landed under a version number computed without them. Whether to retag or cut a follow-up release is a separate call.