### PR TITLE
fix(reporting): serialize webhook createdAt as ISO-8601 string

### DIFF
--- a/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/webhook/controller/WebhookController.kt
+++ b/application/aam-backend-service/src/main/kotlin/com/aamdigital/aambackendservice/reporting/webhook/controller/WebhookController.kt
@@ -11,6 +11,7 @@ import com.aamdigital.aambackendservice.reporting.webhook.core.AddWebhookSubscri
 import com.aamdigital.aambackendservice.reporting.webhook.storage.CreateWebhookRequest
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookOwner
 import com.aamdigital.aambackendservice.reporting.webhook.storage.WebhookStorage
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -40,6 +41,11 @@ data class WebhookDto(
     val authentication: WebhookAuthenticationReadDto,
     val owner: WebhookOwner,
     val reportSubscriptions: MutableList<String>,
+    // the app's shared ObjectMapper is built via a bare Jackson2ObjectMapperBuilder() (see
+    // ObjectMapperConfiguration), which leaves WRITE_DATES_AS_TIMESTAMPS at Jackson's raw default
+    // (enabled) instead of Spring Boot's usual override - without this, Instant serializes as a
+    // numeric epoch value instead of the ISO-8601 string the OpenAPI spec documents.
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     val createdAt: Instant?
 )
 


### PR DESCRIPTION
## Summary
- CI on main failed after fec6a3c: https://github.com/Aam-Digital/aam-services/actions/runs/34255179822 (4 e2e test failures in the Webhook feature)
- Root cause: `WebhookDto.createdAt` (an `Instant`) was serialized by the app's shared `ObjectMapper` as a numeric epoch value instead of an ISO-8601 string, because `ObjectMapperConfiguration` builds a bare `Jackson2ObjectMapperBuilder()` that leaves `WRITE_DATES_AS_TIMESTAMPS` at Jackson's raw default (enabled), unlike Spring Boot's usual auto-configured mapper. This tripped the `reporting` module's strict OpenAPI contract check, since the spec documents `createdAt` as `type: string, format: date-time`.
- Fix: annotate the field with `@JsonFormat(shape = JsonFormat.Shape.STRING)` to force ISO-8601 string output for this field specifically, without changing the shared `ObjectMapper`'s app-wide behavior (a broader fix/refactor of `ObjectMapperConfiguration` is out of scope here and would need its own review, since other endpoints could depend on the current numeric behavior).

## Test plan
- [x] `./gradlew clean test` (full suite, unit + Cucumber e2e via Testcontainers): 342 tests, 0 failures (previously 4 failed)
- [x] Confirmed via `CUCUMBER_FILTER_TAGS="@Webhook"` locally that all Webhook feature scenarios pass, including `GET /v1/reporting/webhook` and `GET /v1/reporting/webhook/{id}` responses validating against `docs/api-specs/reporting-api-v1.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)